### PR TITLE
Support for when-notation

### DIFF
--- a/src/ast/expr/WhenExpr.php
+++ b/src/ast/expr/WhenExpr.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Quack Compiler and toolkit
+ * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
+ * CONTRIBUTORS.
+ *
+ * This file is part of Quack.
+ *
+ * Quack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Quack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Quack.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace QuackCompiler\Ast\Expr;
+
+use \QuackCompiler\Parser\Parser;
+
+class WhenExpr implements Expr
+{
+  public $cases;
+
+  public function __construct($cases)
+  {
+    $this->cases = $cases;
+  }
+
+  public function format(Parser $_)
+  {
+  }
+}

--- a/src/lexer/SymbolDecypher.php
+++ b/src/lexer/SymbolDecypher.php
@@ -35,11 +35,11 @@ class SymbolDecypher
       case '>':
         return static::tryMatch($context, ['>>>', '>=', '>>']);
       case ':':
-        return static::tryMatch($context, [':-', ':?']);
+        return static::tryMatch($context, [':-']);
       case '+':
         return static::tryMatch($context, ['+++', '++']);
       case '?':
-        return static::tryMatch($context, ['?:', '??']);
+        return static::tryMatch($context, ['?.', '?:', '??']);
       case '*':
         return static::tryMatch($context, ['**']);
       case '=':
@@ -48,6 +48,8 @@ class SymbolDecypher
         return static::tryMatch($context, ['|>']);
       case '^':
         return static::tryMatch($context, ['^^']);
+      case '-':
+        return static::tryMatch($context, ['->']);
       case '&':
         if (ctype_digit($context->preview())) {
           $context->consume();

--- a/src/parselets/WhenParselet.php
+++ b/src/parselets/WhenParselet.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Quack Compiler and toolkit
+ * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
+ * CONTRIBUTORS.
+ *
+ * This file is part of Quack.
+ *
+ * Quack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Quack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Quack.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace QuackCompiler\Parselets;
+
+use \QuackCompiler\Parser\Precedence;
+use \QuackCompiler\Parser\Grammar;
+use \QuackCompiler\Ast\Expr\WhenExpr;
+use \QuackCompiler\Lexer\Token;
+use \QuackCompiler\Lexer\Tag;
+
+class WhenParselet implements IPrefixParselet
+{
+  public function parse(Grammar $grammar, Token $token)
+  {
+    $cases = [];
+
+    do {
+      $grammar->parser->consume();
+
+      // Default operation
+      if ($grammar->parser->is(Tag::T_ELSE)) {
+        $grammar->parser->consume();
+        $default = new \stdClass;
+        $default->condition = NULL;
+        $default->action = $grammar->_expr();
+        $cases[] = $default;
+        goto fetch_next;
+      }
+
+      $case = new \stdClass;
+      $case->condition = $grammar->_expr();
+      $grammar->parser->match('->');
+      $case->action = $grammar->_expr();
+      $cases[] = $case;
+
+      fetch_next:
+      if (!$grammar->parser->is(Tag::T_END)) {
+        $grammar->parser->match(';');
+      }
+
+    } while ($grammar->parser->is('|'));
+
+    $grammar->parser->match(Tag::T_END);
+
+    return new WhenExpr($cases);
+  }
+}

--- a/src/parser/Parser.php
+++ b/src/parser/Parser.php
@@ -40,6 +40,7 @@ use \QuackCompiler\Parselets\ArrayParselet;
 use \QuackCompiler\Parselets\NewParselet;
 use \QuackCompiler\Parselets\MemberAccessParselet;
 use \QuackCompiler\Parselets\KeywordParselet;
+use \QuackCompiler\Parselets\WhenParselet;
 
 abstract class Parser
 {
@@ -99,10 +100,11 @@ abstract class Parser
     $this->register(Tag::T_INCLUDE, new IncludeParselet);
     $this->register('#', new NewParselet);
     $this->register('.', new MemberAccessParselet);
-    $this->register('?:', new MemberAccessParselet);
+    $this->register('?.', new MemberAccessParselet);
     $this->register(Tag::T_TRUE, new KeywordParselet);
     $this->register(Tag::T_FALSE, new KeywordParselet);
     $this->register(Tag::T_NIL, new KeywordParselet);
+    $this->register(Tag::T_WHEN, new WhenParselet);
 
     $this->prefix('+', Precedence::PREFIX);
     $this->prefix('-', Precedence::PREFIX);

--- a/src/parser/TokenChecker.php
+++ b/src/parser/TokenChecker.php
@@ -82,6 +82,7 @@ class TokenChecker
         || $this->parser->is(Tag::T_TRUE)
         || $this->parser->is(Tag::T_FALSE)
         || $this->parser->is(Tag::T_NIL)
+        || $this->parser->is(Tag::T_WHEN)
         || $this->parser->isOperator()
         || $this->parser->is('{')
         || $this->parser->is('(');

--- a/src/toolkit/QuackToolkit.php
+++ b/src/toolkit/QuackToolkit.php
@@ -63,6 +63,7 @@ import(PARSELETS, 'NameParselet');
 import(PARSELETS, 'NewParselet');
 import(PARSELETS, 'MemberAccessParselet');
 import(PARSELETS, 'KeywordParselet');
+import(PARSELETS, 'WhenParselet');
 
 /* Ast */
 
@@ -83,6 +84,7 @@ import(AST, 'expr/PostfixExpr');
 import(AST, 'expr/TernaryExpr');
 import(AST, 'expr/NilExpr');
 import(AST, 'expr/BoolExpr');
+import(AST, 'expr/WhenExpr');
 
 import(AST, 'stmt/Stmt');
 import(AST, 'stmt/BlockStmt');


### PR DESCRIPTION
This pull-request implements support for the `when-notation` on Quack compiler. `when` is now an expression to pick an expression when it satisfies a specific condition. It is a returnable form of `switch` statement.

Code that would be written as:

``` erlang
let a :- 10
let b :- nil
if a < 3
  do b :- "foo"
elif a < 6
  do b :- "bar"
else
  do b :- "baz"
end
```

Now is:

``` erlang
let a :- 10
let b :- when
  | a < 3 -> "foo";
  | a < 6 -> "bar";
  | else     "baz"
end
```

Note that the value is returned directly, different from `switch` or `if` statement.

Footnotes
[1] - The semicolon on the last `left` `->` `right` is optional
[2] - `->` is **not** an operator and has no associativity
