### PR TITLE
Implemented support for strings

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,3 +20,4 @@
 - [x] Store numbers as strings instead of integers
 - [ ] Implement static properties (without semantic validation)
 - [ ] Make a sandwich (because I'm hungry)
+- [x] Implement strings as expressions

--- a/src/ast/expr/StringExpr.php
+++ b/src/ast/expr/StringExpr.php
@@ -19,16 +19,21 @@
  * You should have received a copy of the GNU General Public License
  * along with Quack.  If not, see <http://www.gnu.org/licenses/>.
  */
-namespace QuackCompiler\Parselets;
+namespace QuackCompiler\Ast\Expr;
 
-use \QuackCompiler\Ast\Expr\NameExpr;
-use \QuackCompiler\Lexer\Token;
-use \QuackCompiler\Parser\Grammar;
+use \QuackCompiler\Parser\Parser;
 
-class NameParselet implements IPrefixParselet
+class StringExpr implements Expr
 {
-  public function parse(Grammar $grammar, Token $token)
+  public $value;
+
+  public function __construct($value)
   {
-    return new NameExpr($grammar->parser->resolveScope($token->getPointer()));
+    $this->value = $value;
+  }
+
+  public function format(Parser $parser)
+  {
+    return $this->value;
   }
 }

--- a/src/parselets/StringParselet.php
+++ b/src/parselets/StringParselet.php
@@ -21,14 +21,14 @@
  */
 namespace QuackCompiler\Parselets;
 
-use \QuackCompiler\Ast\Expr\NameExpr;
+use \QuackCompiler\Ast\Expr\StringExpr;
 use \QuackCompiler\Lexer\Token;
 use \QuackCompiler\Parser\Grammar;
 
-class NameParselet implements IPrefixParselet
+class StringParselet implements IPrefixParselet
 {
   public function parse(Grammar $grammar, Token $token)
   {
-    return new NameExpr($grammar->parser->resolveScope($token->getPointer()));
+    return new StringExpr($grammar->parser->resolveScope($token->getPointer()));
   }
 }

--- a/src/parser/Parser.php
+++ b/src/parser/Parser.php
@@ -41,6 +41,7 @@ use \QuackCompiler\Parselets\NewParselet;
 use \QuackCompiler\Parselets\MemberAccessParselet;
 use \QuackCompiler\Parselets\KeywordParselet;
 use \QuackCompiler\Parselets\WhenParselet;
+use \QuackCompiler\Parselets\StringParselet;
 
 abstract class Parser
 {
@@ -91,6 +92,7 @@ abstract class Parser
   {
     $this->register(Tag::T_INTEGER, new NumberParselet);
     $this->register(Tag::T_DOUBLE, new NumberParselet);
+    $this->register(Tag::T_STRING, new StringParselet);
     $this->register(Tag::T_IDENT, new NameParselet);
     $this->register(Tag::T_THEN, new TernaryParselet);
     $this->register('(', new GroupParselet);

--- a/src/parser/TokenChecker.php
+++ b/src/parser/TokenChecker.php
@@ -83,6 +83,7 @@ class TokenChecker
         || $this->parser->is(Tag::T_FALSE)
         || $this->parser->is(Tag::T_NIL)
         || $this->parser->is(Tag::T_WHEN)
+        || $this->parser->is(Tag::T_STRING)
         || $this->parser->isOperator()
         || $this->parser->is('{')
         || $this->parser->is('(');

--- a/src/toolkit/QuackToolkit.php
+++ b/src/toolkit/QuackToolkit.php
@@ -64,6 +64,7 @@ import(PARSELETS, 'NewParselet');
 import(PARSELETS, 'MemberAccessParselet');
 import(PARSELETS, 'KeywordParselet');
 import(PARSELETS, 'WhenParselet');
+import(PARSELETS, 'StringParselet');
 
 /* Ast */
 
@@ -85,6 +86,7 @@ import(AST, 'expr/TernaryExpr');
 import(AST, 'expr/NilExpr');
 import(AST, 'expr/BoolExpr');
 import(AST, 'expr/WhenExpr');
+import(AST, 'expr/StringExpr');
 
 import(AST, 'stmt/Stmt');
 import(AST, 'stmt/BlockStmt');


### PR DESCRIPTION
This pull-request implements support for strings in Quack language. It is self-descriptive. Now, finally, strings can be used as expressions. Please review and merge.
