### PR TITLE
Implemented function call

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@
 - [x] Object access syntax should use (.) instead of (:)
 - [x] Re-implement atoms
 - [x] Implement post-conditionals for expression statements
-- [ ] Implement function invocation
+- [x] Implement function invocation
 - [ ] Implement array access
 - [x] Implement when notation
 - [ ] Analysis about during {n} times syntax.

--- a/src/ast/expr/CallExpr.php
+++ b/src/ast/expr/CallExpr.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Quack Compiler and toolkit
+ * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
+ * CONTRIBUTORS.
+ *
+ * This file is part of Quack.
+ *
+ * Quack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Quack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Quack.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace QuackCompiler\Ast\Expr;
+
+use \QuackCompiler\Parser\Parser;
+
+class CallExpr implements Expr
+{
+  public $func;
+  public $arguments;
+
+  public function __construct($func, $arguments)
+  {
+    $this->func = $func;
+    $this->arguments = $arguments;
+  }
+
+  public function format(Parser $parser)
+  {
+    throw new \Exception;
+  }
+}

--- a/src/parselets/CallParselet.php
+++ b/src/parselets/CallParselet.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Quack Compiler and toolkit
+ * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
+ * CONTRIBUTORS.
+ *
+ * This file is part of Quack.
+ *
+ * Quack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Quack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Quack.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace QuackCompiler\Parselets;
+
+use \QuackCompiler\Ast\Expr\CallExpr;
+use \QuackCompiler\Ast\Expr\Expr;
+use \QuackCompiler\Lexer\Token;
+use \QuackCompiler\Parser\Grammar;
+use \QuackCompiler\Parser\Precedence;
+
+class CallParselet implements IInfixParselet
+{
+  public function parse(Grammar $grammar, Expr $left, Token $token)
+  {
+    $args = [];
+
+    if (!$grammar->parser->is(']')) {
+      $args[] = $grammar->_expr();
+
+      while ($grammar->parser->is(';')) {
+        $grammar->parser->consume();
+        $args[] = $grammar->_expr();
+      }
+    }
+
+    $grammar->parser->match(']');
+
+    return new CallExpr($left, $args);
+  }
+
+  public function getPrecedence()
+  {
+    return Precedence::CALL;
+  }
+}

--- a/src/parser/Parser.php
+++ b/src/parser/Parser.php
@@ -42,6 +42,7 @@ use \QuackCompiler\Parselets\MemberAccessParselet;
 use \QuackCompiler\Parselets\KeywordParselet;
 use \QuackCompiler\Parselets\WhenParselet;
 use \QuackCompiler\Parselets\StringParselet;
+use \QuackCompiler\Parselets\CallParselet;
 
 abstract class Parser
 {
@@ -96,6 +97,7 @@ abstract class Parser
     $this->register(Tag::T_IDENT, new NameParselet);
     $this->register(Tag::T_THEN, new TernaryParselet);
     $this->register('(', new GroupParselet);
+    $this->register('[', new CallParselet);
     $this->register('{', new ArrayParselet);
     $this->register(Tag::T_FN, new FunctionParselet);
     $this->register(Tag::T_REQUIRE, new IncludeParselet);

--- a/src/parser/Precedence.php
+++ b/src/parser/Precedence.php
@@ -43,5 +43,6 @@ class Precedence
   const POSTFIX            = 18;
   const TYPE_CAST          = 19;
   const EXPONENT           = 20;
+  const CALL               = 21;
   // TODO: Define other operators, build operators table
 }

--- a/src/toolkit/QuackToolkit.php
+++ b/src/toolkit/QuackToolkit.php
@@ -65,6 +65,7 @@ import(PARSELETS, 'MemberAccessParselet');
 import(PARSELETS, 'KeywordParselet');
 import(PARSELETS, 'WhenParselet');
 import(PARSELETS, 'StringParselet');
+import(PARSELETS, 'CallParselet');
 
 /* Ast */
 
@@ -87,6 +88,7 @@ import(AST, 'expr/NilExpr');
 import(AST, 'expr/BoolExpr');
 import(AST, 'expr/WhenExpr');
 import(AST, 'expr/StringExpr');
+import(AST, 'expr/CallExpr');
 
 import(AST, 'stmt/Stmt');
 import(AST, 'stmt/BlockStmt');


### PR DESCRIPTION
This pull-request implements function call on Quack compiler.
Now, it is possible to expressions be used like functions. The validation **will be semantic**, and not by syntax, like PHP does.

We finally can do such things:

``` erlang
let a :- fn { x; y | x + y } [ 10; 20 ]
```

That will produce `30`. Parenthesis are not necessary!

The rules for function call are:

``` erlang
call := <expr> [ <expr> (;) ... ]
```
