### PR TITLE
Remove unnecessary count in Lexer::preview()

### DIFF
--- a/src/lexer/Lexer.php
+++ b/src/lexer/Lexer.php
@@ -134,7 +134,7 @@ abstract class Lexer
   {
     $next = $this->position + $n;
 
-    return $next >= strlen($this->input)
+    return $next >= $this->size
       ? /* then      */ self::EOF
       : /* otherwise */ $this->input[$next];
   }
@@ -149,11 +149,14 @@ abstract class Lexer
 
   public function matches($string)
   {
-    for ($i = 0; $i < strlen($string); $i++) {
+    $len = strlen($string);
+
+    for ($i = 0; $i < $len; $i++) {
       if ($this->preview($i) !== $string[$i]) {
         return false;
       }
     }
+
     return true;
   }
 


### PR DESCRIPTION
```
if ($this->size === 0) {
   exit;
}
```

We need to stop the program?

Maybe `if (false === isset($input[0])) {` avoid a count to check if `$input` empty
