### PR TITLE
Array access

### DIFF
--- a/src/ast/expr/AccessExpr.php
+++ b/src/ast/expr/AccessExpr.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Quack Compiler and toolkit
+ * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
+ * CONTRIBUTORS.
+ *
+ * This file is part of Quack.
+ *
+ * Quack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Quack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Quack.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace QuackCompiler\Ast\Expr;
+
+use \QuackCompiler\Parser\Parser;
+
+class AccessExpr implements Expr
+{
+  public $left;
+  public $index;
+
+  public function __construct($left, $index)
+  {
+    $this->left = $left;
+    $this->index = $index;
+  }
+
+  public function format(Parser $parser)
+  {
+    throw new \Exception;
+  }
+}

--- a/src/parselets/AccessParselet.php
+++ b/src/parselets/AccessParselet.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Quack Compiler and toolkit
+ * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
+ * CONTRIBUTORS.
+ *
+ * This file is part of Quack.
+ *
+ * Quack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Quack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Quack.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace QuackCompiler\Parselets;
+
+use \QuackCompiler\Ast\Expr\AccessExpr;
+use \QuackCompiler\Ast\Expr\Expr;
+use \QuackCompiler\Lexer\Token;
+use \QuackCompiler\Parser\Grammar;
+use \QuackCompiler\Parser\Precedence;
+
+class AccessParselet implements IInfixParselet
+{
+  public function parse(Grammar $grammar, Expr $left, Token $token)
+  {
+    $index = $grammar->_expr();
+    $grammar->parser->match('}');
+
+    return new AccessExpr($left, $index);
+  }
+
+  public function getPrecedence()
+  {
+    return Precedence::ACCESS;
+  }
+}

--- a/src/parselets/MemberAccessParselet.php
+++ b/src/parselets/MemberAccessParselet.php
@@ -36,7 +36,8 @@ class MemberAccessParselet implements IInfixParselet
   public function parse(Grammar $grammar, Expr $left, Token $token)
   {
     $right = $grammar->_name();
-    return new OperatorExpr($left, $token->getTag(), new NameExpr($right));
+    return new OperatorExpr($left, $token->getTag(),
+      new NameExpr($grammar->parser->resolveScope($right->getPointer())));
   }
 
   public function getPrecedence()

--- a/src/parser/Grammar.php
+++ b/src/parser/Grammar.php
@@ -629,8 +629,6 @@ class Grammar
   /* Coproductions */
   function qualifiedName()
   {
-    print 'foo';
-
     $symbol_pointers = [$this->parser->match(Tag::T_IDENT)];
     while ($this->parser->is('.')) {
       $this->parser->consume();

--- a/src/parser/Grammar.php
+++ b/src/parser/Grammar.php
@@ -629,6 +629,8 @@ class Grammar
   /* Coproductions */
   function qualifiedName()
   {
+    print 'foo';
+
     $symbol_pointers = [$this->parser->match(Tag::T_IDENT)];
     while ($this->parser->is('.')) {
       $this->parser->consume();

--- a/src/parser/Parser.php
+++ b/src/parser/Parser.php
@@ -43,6 +43,7 @@ use \QuackCompiler\Parselets\KeywordParselet;
 use \QuackCompiler\Parselets\WhenParselet;
 use \QuackCompiler\Parselets\StringParselet;
 use \QuackCompiler\Parselets\CallParselet;
+use \QuackCompiler\Parselets\AccessParselet;
 
 abstract class Parser
 {
@@ -99,6 +100,7 @@ abstract class Parser
     $this->register('(', new GroupParselet);
     $this->register('[', new CallParselet);
     $this->register('{', new ArrayParselet);
+    $this->register('{', new AccessParselet);
     $this->register(Tag::T_FN, new FunctionParselet);
     $this->register(Tag::T_REQUIRE, new IncludeParselet);
     $this->register(Tag::T_INCLUDE, new IncludeParselet);

--- a/src/parser/Precedence.php
+++ b/src/parser/Precedence.php
@@ -44,5 +44,6 @@ class Precedence
   const TYPE_CAST          = 19;
   const EXPONENT           = 20;
   const CALL               = 21;
-  // TODO: Define other operators, build operators table
+  const ACCESS             = 22;
+  // TODO: Review operators precedence when finish the parser
 }

--- a/src/toolkit/QuackToolkit.php
+++ b/src/toolkit/QuackToolkit.php
@@ -66,6 +66,7 @@ import(PARSELETS, 'KeywordParselet');
 import(PARSELETS, 'WhenParselet');
 import(PARSELETS, 'StringParselet');
 import(PARSELETS, 'CallParselet');
+import(PARSELETS, 'AccessParselet');
 
 /* Ast */
 
@@ -89,6 +90,7 @@ import(AST, 'expr/BoolExpr');
 import(AST, 'expr/WhenExpr');
 import(AST, 'expr/StringExpr');
 import(AST, 'expr/CallExpr');
+import(AST, 'expr/AccessExpr');
 
 import(AST, 'stmt/Stmt');
 import(AST, 'stmt/BlockStmt');


### PR DESCRIPTION
This pull-request implements support on Quack compiler for array access.
The following syntax has been chosen: `<expr> { <expr> }`.

Usage examples:

``` sml
(* Function that gets the first item of a list *)
let fst :- fn { xss | xss{ 0 } }

print { "wow"; "such"; "good"; "nice"; "feature" }{ 3 } (* nice *)

do request[ :get; url ]{ "status_code" }
|> bind [ fn { code | when
  | 200  -> :ok;
  | else -> :error end
} ]
|> print
```

Go, go, go!
