### PR TITLE
[WIP] Removing Python references from the compiler (#12)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,6 @@ repl:
 ifeq ($(mode), ast)
 	cd src/repl; php QuackRepl.php --ast
 else
-ifeq ($(mode), python)
-	cd src/repl; php QuackRepl.php --python
-else
 	@echo No mode for repl
 endif
 endif

--- a/src/Quack.php
+++ b/src/Quack.php
@@ -40,7 +40,6 @@ Common:
   -op, --optimize                   Enables code optimization on generated code
 
 Target:
-  --python                          Compiles to Python
   --php                             Compiles to PHP
   --es5                             Compiles to ECMAScript 5
   --es6                             Compiles to ECMAScript 6

--- a/src/ast/expr/BoolExpr.php
+++ b/src/ast/expr/BoolExpr.php
@@ -36,9 +36,4 @@ class BoolExpr implements Expr
   {
     return $this->value ? 'true' : 'false';
   }
-
-  public function python(Parser $_)
-  {
-    return $this->value ? 'True' : 'False';
-  }
 }

--- a/src/ast/expr/NameExpr.php
+++ b/src/ast/expr/NameExpr.php
@@ -36,9 +36,4 @@ class NameExpr implements Expr
   {
     return $parser->resolveScope($this->token->getPointer());
   }
-
-  public function python(Parser $parser)
-  {
-    return $this->format($parser);
-  }
 }

--- a/src/ast/expr/NilExpr.php
+++ b/src/ast/expr/NilExpr.php
@@ -32,8 +32,4 @@ class NilExpr implements Expr
     return 'nil';
   }
 
-  public function python(Parser $_)
-  {
-    return 'None';
-  }
 }

--- a/src/ast/expr/OperatorExpr.php
+++ b/src/ast/expr/OperatorExpr.php
@@ -48,16 +48,4 @@ class OperatorExpr implements Expr
     $string_builder[] = ')';
     return implode($string_builder);
   }
-
-  public function python(Parser $parser)
-  {
-    $string_builder = ['('];
-    $string_builder[] = $this->left->python($parser);
-    $string_builder[] = ' ';
-    $string_builder[] = Tag::getPunctuator($this->operator);
-    $string_builder[] = ' ';
-    $string_builder[] = $this->right->python($parser);
-    $string_builder[] = ')';
-    return implode($string_builder);
-  }
 }

--- a/src/ast/expr/PostfixExpr.php
+++ b/src/ast/expr/PostfixExpr.php
@@ -44,12 +44,4 @@ class PostfixExpr implements Expr
     return implode($string_builder);
   }
 
-  public function python(Parser $parser)
-  {
-    $string_builder = ['('];
-    $string_builder[] = $this->left->python($parser);
-    $string_builder[] = Tag::getPunctuator($this->operator);
-    $string_builder[] = ')';
-    return implode($string_builder);
-  }
 }

--- a/src/ast/expr/PrefixExpr.php
+++ b/src/ast/expr/PrefixExpr.php
@@ -50,18 +50,4 @@ class PrefixExpr implements Expr
     return implode($string_builder);
   }
 
-  public function python(Parser $parser)
-  {
-    $string_builder = [];
-    if ($this->operator === Tag::T_NOT) {
-      $string_builder[] = '!';
-    } else if ($this->operator === '*') {
-      // pass
-    } else {
-      $string_builder[] = $this->operator;
-    }
-
-    $string_builder[] = $this->right->python($parser);
-    return implode($string_builder);
-  }
 }

--- a/src/ast/expr/TernaryExpr.php
+++ b/src/ast/expr/TernaryExpr.php
@@ -48,15 +48,4 @@ class TernaryExpr implements Expr
     return implode($string_builder);
   }
 
-  public function python(Parser $parser)
-  {
-    $string_builder = ['('];
-    $string_builder[] = $this->then->python($parser);
-    $string_builder[] = ' if ';
-    $string_builder[] = $this->condition->python($parser);
-    $string_builder[] = ' else ';
-    $string_builder[] = $this->else->python($parser);
-    $string_builder[] = ')';
-    return implode($string_builder);
-  }
 }

--- a/src/ast/stmt/BlockStmt.php
+++ b/src/ast/stmt/BlockStmt.php
@@ -51,20 +51,4 @@ class BlockStmt implements Stmt
     return implode($string_builder);
   }
 
-  public function python(Parser $parser)
-  {
-    if (sizeof($this->stmt_list) == 0) {
-      return "pass\n";
-    }
-
-    $parser->openScope();
-
-    foreach ($this->stmt_list as $stmt) {
-      $string_builder[] = $parser->indent() . $stmt->python($parser);
-    }
-
-    $string_builder[] = $parser->dedent();
-    $parser->closeScope();
-    return implode($string_builder);
-  }
 }

--- a/src/ast/stmt/ExprStmt.php
+++ b/src/ast/stmt/ExprStmt.php
@@ -39,10 +39,4 @@ class ExprStmt implements Stmt
     return implode($string_builder);
   }
 
-  public function python(Parser $parser)
-  {
-    $string_builder = [$this->expression->python($parser)];
-    $string_builder[] = "\n";
-    return implode($string_builder);
-  }
 }

--- a/src/ast/stmt/ForStmt.php
+++ b/src/ast/stmt/ForStmt.php
@@ -46,8 +46,4 @@ class ForStmt implements Stmt
     throw new \Exception('TODO');
   }
 
-  public function python(Parser $parser)
-  {
-    throw new \Exception('TODO');
-  }
 }

--- a/src/ast/stmt/ReturnStmt.php
+++ b/src/ast/stmt/ReturnStmt.php
@@ -45,16 +45,4 @@ class ReturnStmt implements Stmt
     return implode($string_builder);
   }
 
-  public function python(Parser $parser)
-  {
-    $string_builder = ['return'];
-
-    if (!is_null($this->expression)) {
-      $string_builder[] = ' ';
-      $string_builder[] = $this->expression->python($parser);
-      $string_builder[] = PHP_EOL;
-    }
-
-    return implode($string_builder);
-  }
 }

--- a/src/ast/stmt/WhileStmt.php
+++ b/src/ast/stmt/WhileStmt.php
@@ -53,21 +53,4 @@ class WhileStmt implements Stmt
     return implode($string_builder);
   }
 
-  public function python(Parser $parser)
-  {
-    $is_simple = !($this->body instanceof BlockStmt);
-    $string_builder = ['while '];
-    $string_builder[] = $this->condition->python($parser);
-    $string_builder[] = ":\n";
-
-    if ($is_simple) {
-      $string_builder[] = "\n";
-      $parser->openScope();
-      $string_builder[] = $parser->indent();
-      $parser->closeScope();
-    }
-
-    $string_builder[] = $this->body->python($parser);
-    return implode($string_builder);
-  }
 }

--- a/src/parser/TokenReader.php
+++ b/src/parser/TokenReader.php
@@ -80,13 +80,6 @@ class TokenReader extends Parser
     return implode($source);
   }
 
-  public function python()
-  {
-    foreach ($this->ast as $stmt) {
-      echo $stmt->python($this);
-    }
-  }
-
   public function parse()
   {
     $this->ast = $this->grammar->start();

--- a/src/repl/QuackRepl.php
+++ b/src/repl/QuackRepl.php
@@ -80,7 +80,6 @@ function readline_callback($command)
   try {
     $parser->parse();
     /* when */ args_have('-a', '--ast') && $parser->dumpAst();
-    /* when */ args_have('-p', '--python') && $parser->python($parser);
   } catch (SyntaxError $e) {
     echo $e;
   }


### PR DESCRIPTION
This PR addresses issue #12, and the commits do:
- [x] Remove the reference from [Makefile](https://github.com/quack/quack/blob/master/Makefile#L10)
- [x] Remove methods from [`src/ast/expr`](https://github.com/quack/quack/tree/master/src/ast/expr)
- [x] Remove methods from [`src/ast/stmt`](https://github.com/quack/quack/tree/master/src/ast/stmt)
- [x] Remove reference from [Quack REPL](https://github.com/quack/quack/blob/master/src/repl/QuackRepl.php#L83)
- [x] Remove method from [TokenReader]
