### PR TITLE
Implemented atoms as expressions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,6 +18,10 @@
 - [x] Make a sandwich (because I'm hungry)
 - [x] Implement strings as expressions
 - [x] Implement `<expr> .. <expr> by <expr>` syntax
+- [x] Implement atoms as expressions
 - [ ] Implement short syntax for `open` statements
 - [ ] Implement partial function parsing
 - [ ] Implement static properties (without semantic validation)
+- [ ] Verify property definitions for classes
+- [ ] Verify associative array definitions
+- [ ] Create a single parselet for literal values

--- a/src/ast/expr/AtomExpr.php
+++ b/src/ast/expr/AtomExpr.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Quack Compiler and toolkit
+ * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
+ * CONTRIBUTORS.
+ *
+ * This file is part of Quack.
+ *
+ * Quack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Quack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Quack.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace QuackCompiler\Ast\Expr;
+
+use \QuackCompiler\Parser\Parser;
+
+class AtomExpr implements Expr
+{
+  public $value;
+
+  public function __construct($value)
+  {
+    $this->value = $value;
+  }
+
+  public function format(Parser $parser)
+  {
+    return ':' . $this->value;
+  }
+}

--- a/src/parselets/AtomParselet.php
+++ b/src/parselets/AtomParselet.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Quack Compiler and toolkit
+ * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
+ * CONTRIBUTORS.
+ *
+ * This file is part of Quack.
+ *
+ * Quack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Quack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Quack.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace QuackCompiler\Parselets;
+
+use \QuackCompiler\Ast\Expr\AtomExpr;
+use \QuackCompiler\Lexer\Token;
+use \QuackCompiler\Parser\Grammar;
+
+class AtomParselet implements IPrefixParselet
+{
+  public function parse(Grammar $grammar, Token $token)
+  {
+    return new AtomExpr($grammar->parser->resolveScope($token->getPointer()));
+  }
+}

--- a/src/parser/Parser.php
+++ b/src/parser/Parser.php
@@ -45,6 +45,7 @@ use \QuackCompiler\Parselets\StringParselet;
 use \QuackCompiler\Parselets\CallParselet;
 use \QuackCompiler\Parselets\AccessParselet;
 use \QuackCompiler\Parselets\RangeParselet;
+use \QuackCompiler\Parselets\AtomParselet;
 
 abstract class Parser
 {
@@ -112,6 +113,7 @@ abstract class Parser
     $this->register(Tag::T_TRUE, new KeywordParselet);
     $this->register(Tag::T_FALSE, new KeywordParselet);
     $this->register(Tag::T_NIL, new KeywordParselet);
+    $this->register(Tag::T_ATOM, new AtomParselet);
     $this->register(Tag::T_WHEN, new WhenParselet);
 
     $this->prefix('+', Precedence::PREFIX);

--- a/src/parser/TokenChecker.php
+++ b/src/parser/TokenChecker.php
@@ -84,6 +84,7 @@ class TokenChecker
         || $this->parser->is(Tag::T_NIL)
         || $this->parser->is(Tag::T_WHEN)
         || $this->parser->is(Tag::T_STRING)
+        || $this->parser->is(Tag::T_ATOM)
         || $this->parser->isOperator()
         || $this->parser->is('{')
         || $this->parser->is('(');

--- a/src/toolkit/QuackToolkit.php
+++ b/src/toolkit/QuackToolkit.php
@@ -68,6 +68,7 @@ import(PARSELETS, 'StringParselet');
 import(PARSELETS, 'CallParselet');
 import(PARSELETS, 'AccessParselet');
 import(PARSELETS, 'RangeParselet');
+import(PARSELETS, 'AtomParselet');
 
 /* Ast */
 
@@ -93,6 +94,7 @@ import(AST, 'expr/StringExpr');
 import(AST, 'expr/CallExpr');
 import(AST, 'expr/AccessExpr');
 import(AST, 'expr/RangeExpr');
+import(AST, 'expr/AtomExpr');
 
 import(AST, 'stmt/Stmt');
 import(AST, 'stmt/BlockStmt');


### PR DESCRIPTION
This pull-request implements support for atoms as expressions on Quack compiler.
- Example 1 (returning a state):

``` erlang
fn get_parity [n] ^ when
  | n mod 2 = 0 -> :even;
  | else        -> :odd end
end
```
- Example 2 (enum-like):

``` erlang
fn get_user_state
  ^ self.user.active then :online else :offline
end
```

Atoms are represented by `:` + some identifier.
