### PR TITLE
Short syntax for open and expression disambiguation on arrays

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,8 +20,12 @@
 - [x] Implement `<expr> .. <expr> by <expr>` syntax
 - [x] Implement atoms as expressions
 - [x] Create a single parselet for literal values
-- [ ] Implement short syntax for `open` statements
+- [x] Verify associative array definitions
+- [x] Implement short syntax for `open` statements
 - [ ] Implement partial function parsing
 - [ ] Implement static properties (without semantic validation)
 - [ ] Verify property definitions for classes
-- [ ] Verify associative array definitions
+- [ ] Make print an expression and stdout an alias for echo
+- [ ] Implement trait support
+- [ ] Fix line-0-bug
+- [ ] Better syntax error output

--- a/bootstrap/parser/Parser.qk
+++ b/bootstrap/parser/Parser.qk
@@ -2,8 +2,8 @@
 module QuackCompiler.Parser
 
 open .Exception
-open QuackCompiler.Lexer.{ Tag; Token; Tokenizer }
-open QuackCompiler.Parselets.{
+open .QuackCompiler.Lexer { Tag; Token; Tokenizer }
+open .QuackCompiler.Parselets {
   IPrefixParselet; IInfixParselet; BinaryOperatorParselet; NumberParselet;
   NameParselet; PostfixOperatorParselet; PrefixOperatorParselet;
   TernaryParselet; GroupParselet; FunctionParselet; IncludeParselet;

--- a/src/ast/stmt/OpenStmt.php
+++ b/src/ast/stmt/OpenStmt.php
@@ -28,12 +28,14 @@ class OpenStmt implements Stmt
   public $module;
   public $alias;
   public $type;
+  public $subprops;
 
-  public function __construct($module, $alias = NULL, $type = NULL)
+  public function __construct($module, $alias = NULL, $type = NULL, $subprops = NULL)
   {
     $this->module = $module;
     $this->alias = $alias;
     $this->type = $type;
+    $this->subprops = $subprops;
   }
 
   public function format(Parser $parser)

--- a/src/parselets/ArrayParselet.php
+++ b/src/parselets/ArrayParselet.php
@@ -30,7 +30,6 @@ class ArrayParselet implements IPrefixParselet
   public function parse(Grammar $grammar, Token $token)
   {
     $items = iterator_to_array($grammar->_arrayPairList());
-    $grammar->parser->match('}');
     return new ArrayExpr($items);
   }
 }


### PR DESCRIPTION
This pull-request does:
- [x] Verify associative array definitions;
- [x] Implement short syntax for `open` statements.

Associative arrays are defined using `->`, that is not an operator, but a syntactic divisor:

``` sml
(* Create and push to array, then print *)
let person :- { :name -> "Marcelo Camargo"; :age -> 19 }
do person { :favorite_language } :- "Haskell"
print person { :name } ++ " loves " ++ person { :favorite_language }
```

`open` is used to import modules.

Before, you would do:

``` ocaml
open quack.compiler.core.parser
open quack.compiler.core.lexer
open quack.compiler.core.codegen
```

Now you do:

``` ocaml
open quack.compiler.core { parser; lexer; codegen }
```
