### PR TITLE
PSR-2 standard fully adopted by the project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ##Table of Contents
 
 - [Reporting a bug](#reporting-a-bug)
-- [The 5 magic steps](#the-5-magic-steps)
+- [The 6 magic steps](#the-6-magic-steps)
 - [License](#license)
 
 ##Reporting a bug
@@ -16,14 +16,16 @@ If we find an issue that's related, we will reference it and close your issue, s
 5. Include any errors that may be displayed.
 6. Update us if you have any new info, or if the problem resolves itself!
 
-##The 5 magic steps
+##The 6 magic steps
 
 1. Fork it!
 2. Create your feature branch: `git checkout -b my-new-feature`
-3. Commit your changes: `git commit -m 'Add some feature'`
-4. Push to the branch: `git push origin my-new-feature`
-5. Submit a pull request :)
+3. Install your pre-commit hook: `bash /path/to/quack/tools/phpcs-pre-commit/install.sh`
+4. Commit your changes: `git commit -m 'Add some feature'`
+5. Push to the branch: `git push origin my-new-feature`
+6. Submit a pull request :)
 
 ##License
 
 [Quack](https://github.com/haskellcamargo/quack) is distributed under the GNU General Public License, version 3, [available in this repository](master/LICENSE.md). All contributions are assumed to be also licensed under the GPLv3.
+

--- a/TODO.md
+++ b/TODO.md
@@ -20,8 +20,12 @@
 - [x] Implement `<expr> .. <expr> by <expr>` syntax
 - [x] Implement atoms as expressions
 - [x] Create a single parselet for literal values
-- [ ] Implement short syntax for `open` statements
+- [x] Verify associative array definitions
+- [x] Implement short syntax for `open` statements
+- [x] Make print an expression and stdout an alias for echo
 - [ ] Implement partial function parsing
 - [ ] Implement static properties (without semantic validation)
 - [ ] Verify property definitions for classes
-- [ ] Verify associative array definitions
+- [ ] Implement trait support
+- [ ] Fix line-0-bug
+- [ ] Better syntax error output

--- a/bootstrap/parser/Parser.qk
+++ b/bootstrap/parser/Parser.qk
@@ -2,8 +2,8 @@
 module QuackCompiler.Parser
 
 open .Exception
-open QuackCompiler.Lexer.{ Tag; Token; Tokenizer }
-open QuackCompiler.Parselets.{
+open .QuackCompiler.Lexer { Tag; Token; Tokenizer }
+open .QuackCompiler.Parselets {
   IPrefixParselet; IInfixParselet; BinaryOperatorParselet; NumberParselet;
   NameParselet; PostfixOperatorParselet; PrefixOperatorParselet;
   TernaryParselet; GroupParselet; FunctionParselet; IncludeParselet;

--- a/src/Quack.php
+++ b/src/Quack.php
@@ -2,27 +2,27 @@
 
 function args_have()
 {
-  global $argv;
-  return count(array_intersect($argv, func_get_args())) > 0;
+    global $argv;
+    return count(array_intersect($argv, func_get_args())) > 0;
 }
 
 function no_args()
 {
-  global $argv;
-  return count($argv) === 1;
+    global $argv;
+    return count($argv) === 1;
 }
 
 function quack()
 {
-  if (no_args() || args_have('-h', '--help')) {
-    help();
-    return;
-  }
+    if (no_args() || args_have('-h', '--help')) {
+        help();
+        return;
+    }
 }
 
 function help()
 {
-  echo <<<TEXT
+    echo <<<TEXT
 Usage: ./quack [options] [.qk files]
 
 Common:
@@ -51,7 +51,7 @@ Target:
   --plug <backend>                  Plugs your own backend
 
 TEXT
-;
+    ;
 }
 
 quack();

--- a/src/ast/Node.php
+++ b/src/ast/Node.php
@@ -25,5 +25,5 @@ use \QuackCompiler\Parser\Parser;
 
 interface Node
 {
-  function format(Parser $parser);
+    public function format(Parser $parser);
 }

--- a/src/ast/Util.php
+++ b/src/ast/Util.php
@@ -26,20 +26,20 @@ use \QuackCompiler\Parser\Parser;
 
 class Util
 {
-  static function makeBlock($body, Parser $parser)
-  {
-    $string_builder = [];
+    public static function makeBlock($body, Parser $parser)
+    {
+        $string_builder = [];
 
-    if ($body instanceof BlockStmt) {
-      $string_builder[] = $body->format($parser);
-    } else {
-      $string_builder[] = '[';
-      $string_builder[] = PHP_EOL;
-      $string_builder[] = '  ';
-      $string_builder[] = $body->format($parser);
-      $string_builder[] = ']';
+        if ($body instanceof BlockStmt) {
+            $string_builder[] = $body->format($parser);
+        } else {
+            $string_builder[] = '[';
+            $string_builder[] = PHP_EOL;
+            $string_builder[] = '  ';
+            $string_builder[] = $body->format($parser);
+            $string_builder[] = ']';
+        }
+
+        return implode($string_builder);
     }
-
-    return implode($string_builder);
-  }
 }

--- a/src/ast/expr/AccessExpr.php
+++ b/src/ast/expr/AccessExpr.php
@@ -25,17 +25,17 @@ use \QuackCompiler\Parser\Parser;
 
 class AccessExpr implements Expr
 {
-  public $left;
-  public $index;
+    public $left;
+    public $index;
 
-  public function __construct($left, $index)
-  {
-    $this->left = $left;
-    $this->index = $index;
-  }
+    public function __construct($left, $index)
+    {
+        $this->left = $left;
+        $this->index = $index;
+    }
 
-  public function format(Parser $parser)
-  {
-    throw new \Exception;
-  }
+    public function format(Parser $parser)
+    {
+        throw new \Exception;
+    }
 }

--- a/src/ast/expr/ArrayExpr.php
+++ b/src/ast/expr/ArrayExpr.php
@@ -25,15 +25,15 @@ use \QuackCompiler\Parser\Parser;
 
 class ArrayExpr implements Expr
 {
-  public $items;
+    public $items;
 
-  public function __construct($items)
-  {
-    $this->items = $items;
-  }
+    public function __construct($items)
+    {
+        $this->items = $items;
+    }
 
-  public function format(Parser $parser)
-  {
-    throw new \Exception('TODO');
-  }
+    public function format(Parser $parser)
+    {
+        throw new \Exception('TODO');
+    }
 }

--- a/src/ast/expr/ArrayPairExpr.php
+++ b/src/ast/expr/ArrayPairExpr.php
@@ -25,17 +25,17 @@ use \QuackCompiler\Parser\Parser;
 
 class ArrayPairExpr implements Expr
 {
-  public $left;
-  public $right;
+    public $left;
+    public $right;
 
-  public function __construct($left, $right)
-  {
-    $this->left = $left;
-    $this->right = $right;
-  }
+    public function __construct($left, $right)
+    {
+        $this->left = $left;
+        $this->right = $right;
+    }
 
-  public function format(Parser $parser)
-  {
-    throw new \Exception('TODO');
-  }
+    public function format(Parser $parser)
+    {
+        throw new \Exception('TODO');
+    }
 }

--- a/src/ast/expr/AtomExpr.php
+++ b/src/ast/expr/AtomExpr.php
@@ -25,15 +25,15 @@ use \QuackCompiler\Parser\Parser;
 
 class AtomExpr implements Expr
 {
-  public $value;
+    public $value;
 
-  public function __construct($value)
-  {
-    $this->value = $value;
-  }
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
 
-  public function format(Parser $parser)
-  {
-    return ':' . $this->value;
-  }
+    public function format(Parser $parser)
+    {
+        return ':' . $this->value;
+    }
 }

--- a/src/ast/expr/BoolExpr.php
+++ b/src/ast/expr/BoolExpr.php
@@ -25,15 +25,15 @@ use \QuackCompiler\Parser\Parser;
 
 class BoolExpr implements Expr
 {
-  public $value;
+    public $value;
 
-  public function __construct($value)
-  {
-    $this->value = (bool) $value;
-  }
+    public function __construct($value)
+    {
+        $this->value = (bool) $value;
+    }
 
-  public function format(Parser $_)
-  {
-    return $this->value ? 'true' : 'false';
-  }
+    public function format(Parser $_)
+    {
+        return $this->value ? 'true' : 'false';
+    }
 }

--- a/src/ast/expr/CallExpr.php
+++ b/src/ast/expr/CallExpr.php
@@ -25,17 +25,17 @@ use \QuackCompiler\Parser\Parser;
 
 class CallExpr implements Expr
 {
-  public $func;
-  public $arguments;
+    public $func;
+    public $arguments;
 
-  public function __construct($func, $arguments)
-  {
-    $this->func = $func;
-    $this->arguments = $arguments;
-  }
+    public function __construct($func, $arguments)
+    {
+        $this->func = $func;
+        $this->arguments = $arguments;
+    }
 
-  public function format(Parser $parser)
-  {
-    throw new \Exception;
-  }
+    public function format(Parser $parser)
+    {
+        throw new \Exception;
+    }
 }

--- a/src/ast/expr/Expr.php
+++ b/src/ast/expr/Expr.php
@@ -23,4 +23,6 @@ namespace QuackCompiler\Ast\Expr;
 
 use QuackCompiler\Ast\Node;
 
-interface Expr extends Node {}
+interface Expr extends Node
+{
+}

--- a/src/ast/expr/IncludeExpr.php
+++ b/src/ast/expr/IncludeExpr.php
@@ -25,19 +25,19 @@ use \QuackCompiler\Parser\Parser;
 
 class IncludeExpr implements Expr
 {
-  public $type;
-  public $is_once;
-  public $file;
+    public $type;
+    public $is_once;
+    public $file;
 
-  public function __construct($type, $is_once, $file)
-  {
-    $this->type = $type;
-    $this->is_once = $is_once;
-    $this->file = $file;
-  }
+    public function __construct($type, $is_once, $file)
+    {
+        $this->type = $type;
+        $this->is_once = $is_once;
+        $this->file = $file;
+    }
 
-  public function format(Parser $parser)
-  {
-    throw new \Exception('TODO');
-  }
+    public function format(Parser $parser)
+    {
+        throw new \Exception('TODO');
+    }
 }

--- a/src/ast/expr/LambdaExpr.php
+++ b/src/ast/expr/LambdaExpr.php
@@ -25,25 +25,25 @@ use \QuackCompiler\Parser\Parser;
 
 class LambdaExpr implements Expr
 {
-  public $by_reference;
-  public $parameters;
-  public $type;
-  public $body;
-  public $is_static;
-  public $lexical_vars;
+    public $by_reference;
+    public $parameters;
+    public $type;
+    public $body;
+    public $is_static;
+    public $lexical_vars;
 
-  public function __construct($by_reference, $parameters, $type, $body, $is_static, $lexical_vars)
-  {
-    $this->by_reference = $by_reference;
-    $this->parameters = $parameters;
-    $this->type = $type;
-    $this->body = $body;
-    $this->is_static = $is_static;
-    $this->lexical_vars = $lexical_vars;
-  }
+    public function __construct($by_reference, $parameters, $type, $body, $is_static, $lexical_vars)
+    {
+        $this->by_reference = $by_reference;
+        $this->parameters = $parameters;
+        $this->type = $type;
+        $this->body = $body;
+        $this->is_static = $is_static;
+        $this->lexical_vars = $lexical_vars;
+    }
 
-  public function format(Parser $parser)
-  {
-    throw new \Exception('TODO');
-  }
+    public function format(Parser $parser)
+    {
+        throw new \Exception('TODO');
+    }
 }

--- a/src/ast/expr/NameExpr.php
+++ b/src/ast/expr/NameExpr.php
@@ -25,15 +25,15 @@ use \QuackCompiler\Parser\Parser;
 
 class NameExpr implements Expr
 {
-  public $token;
+    public $token;
 
-  public function __construct($token)
-  {
-    $this->token = $token;
-  }
+    public function __construct($token)
+    {
+        $this->token = $token;
+    }
 
-  public function format(Parser $parser)
-  {
-    return $parser->resolveScope($this->token->getPointer());
-  }
+    public function format(Parser $parser)
+    {
+        return $parser->resolveScope($this->token->getPointer());
+    }
 }

--- a/src/ast/expr/NewExpr.php
+++ b/src/ast/expr/NewExpr.php
@@ -25,17 +25,17 @@ use \QuackCompiler\Parser\Parser;
 
 class NewExpr implements Expr
 {
-  public $class_name;
-  public $ctor_args;
+    public $class_name;
+    public $ctor_args;
 
-  public function __construct($class_name, $ctor_args)
-  {
-    $this->class_name = $class_name;
-    $this->ctor_args = $ctor_args;
-  }
+    public function __construct($class_name, $ctor_args)
+    {
+        $this->class_name = $class_name;
+        $this->ctor_args = $ctor_args;
+    }
 
-  public function format(Parser $parser)
-  {
-    throw new \Exception('TODO');
-  }
+    public function format(Parser $parser)
+    {
+        throw new \Exception('TODO');
+    }
 }

--- a/src/ast/expr/NilExpr.php
+++ b/src/ast/expr/NilExpr.php
@@ -25,10 +25,12 @@ use \QuackCompiler\Parser\Parser;
 
 class NilExpr implements Expr
 {
-  public function __construct() {}
+    public function __construct()
+    {
+    }
 
-  public function format(Parser $_)
-  {
-    return 'nil';
-  }
+    public function format(Parser $_)
+    {
+        return 'nil';
+    }
 }

--- a/src/ast/expr/NumberExpr.php
+++ b/src/ast/expr/NumberExpr.php
@@ -25,17 +25,17 @@ use \QuackCompiler\Parser\Parser;
 
 class NumberExpr implements Expr
 {
-  public $value;
-  public $type;
+    public $value;
+    public $type;
 
-  public function __construct($value, $type)
-  {
-    $this->value = $value;
-    $this->type = $type;
-  }
+    public function __construct($value, $type)
+    {
+        $this->value = $value;
+        $this->type = $type;
+    }
 
-  public function format(Parser $parser)
-  {
-    return (string) $this->value;
-  }
+    public function format(Parser $parser)
+    {
+        return (string) $this->value;
+    }
 }

--- a/src/ast/expr/OperatorExpr.php
+++ b/src/ast/expr/OperatorExpr.php
@@ -26,26 +26,26 @@ use \QuackCompiler\Parser\Parser;
 
 class OperatorExpr implements Expr
 {
-  public $left;
-  public $operator;
-  public $right;
+    public $left;
+    public $operator;
+    public $right;
 
-  public function __construct(Expr $left, $operator, Expr $right)
-  {
-    $this->left = $left;
-    $this->operator = $operator;
-    $this->right = $right;
-  }
+    public function __construct(Expr $left, $operator, Expr $right)
+    {
+        $this->left = $left;
+        $this->operator = $operator;
+        $this->right = $right;
+    }
 
-  public function format(Parser $parser)
-  {
-    $string_builder = ['('];
-    $string_builder[] = $this->left->format($parser);
-    $string_builder[] = ' ';
-    $string_builder[] = Tag::getPunctuator($this->operator);
-    $string_builder[] = ' ';
-    $string_builder[] = $this->right->format($parser);
-    $string_builder[] = ')';
-    return implode($string_builder);
-  }
+    public function format(Parser $parser)
+    {
+        $string_builder = ['('];
+        $string_builder[] = $this->left->format($parser);
+        $string_builder[] = ' ';
+        $string_builder[] = Tag::getPunctuator($this->operator);
+        $string_builder[] = ' ';
+        $string_builder[] = $this->right->format($parser);
+        $string_builder[] = ')';
+        return implode($string_builder);
+    }
 }

--- a/src/ast/expr/PostfixExpr.php
+++ b/src/ast/expr/PostfixExpr.php
@@ -26,22 +26,21 @@ use \QuackCompiler\Parser\Parser;
 
 class PostfixExpr implements Expr
 {
-  public $left;
-  public $operator;
+    public $left;
+    public $operator;
 
-  public function __construct($left, $operator)
-  {
-    $this->left = $left;
-    $this->operator = $operator;
-  }
+    public function __construct($left, $operator)
+    {
+        $this->left = $left;
+        $this->operator = $operator;
+    }
 
-  public function format(Parser $parser)
-  {
-    $string_builder = ['('];
-    $string_builder[] = $this->left->format($parser);
-    $string_builder[] = Tag::getPunctuator($this->operator);
-    $string_builder[] = ')';
-    return implode($string_builder);
-  }
-
+    public function format(Parser $parser)
+    {
+        $string_builder = ['('];
+        $string_builder[] = $this->left->format($parser);
+        $string_builder[] = Tag::getPunctuator($this->operator);
+        $string_builder[] = ')';
+        return implode($string_builder);
+    }
 }

--- a/src/ast/expr/PrefixExpr.php
+++ b/src/ast/expr/PrefixExpr.php
@@ -27,27 +27,26 @@ use \QuackCompiler\Parser\Parser;
 
 class PrefixExpr implements Expr
 {
-  private $operator;
-  private $right;
+    private $operator;
+    private $right;
 
-  public function __construct(Token $operator, Expr $right)
-  {
-    $this->operator = $operator->getTag();
-    $this->right = $right;
-  }
-
-  public function format(Parser $parser)
-  {
-    $string_builder = [];
-    if ($this->operator === Tag::T_NOT) {
-      $string_builder[] = 'not ';
-    } else {
-      $string_builder[] = $this->operator;
+    public function __construct(Token $operator, Expr $right)
+    {
+        $this->operator = $operator->getTag();
+        $this->right = $right;
     }
 
-    $string_builder[] = $this->right->format($parser);
+    public function format(Parser $parser)
+    {
+        $string_builder = [];
+        if ($this->operator === Tag::T_NOT) {
+            $string_builder[] = 'not ';
+        } else {
+            $string_builder[] = $this->operator;
+        }
 
-    return implode($string_builder);
-  }
+        $string_builder[] = $this->right->format($parser);
 
+        return implode($string_builder);
+    }
 }

--- a/src/ast/expr/RangeExpr.php
+++ b/src/ast/expr/RangeExpr.php
@@ -25,19 +25,19 @@ use \QuackCompiler\Parser\Parser;
 
 class RangeExpr implements Expr
 {
-  public $from;
-  public $to;
-  public $by;
+    public $from;
+    public $to;
+    public $by;
 
-  public function __construct($from, $to, $by)
-  {
-    $this->from = $from;
-    $this->to = $to;
-    $this->by = $by;
-  }
+    public function __construct($from, $to, $by)
+    {
+        $this->from = $from;
+        $this->to = $to;
+        $this->by = $by;
+    }
 
-  public function format(Parser $parser)
-  {
-    throw new \Exception;
-  }
+    public function format(Parser $parser)
+    {
+        throw new \Exception;
+    }
 }

--- a/src/ast/expr/StringExpr.php
+++ b/src/ast/expr/StringExpr.php
@@ -25,15 +25,15 @@ use \QuackCompiler\Parser\Parser;
 
 class StringExpr implements Expr
 {
-  public $value;
+    public $value;
 
-  public function __construct($value)
-  {
-    $this->value = $value;
-  }
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
 
-  public function format(Parser $parser)
-  {
-    return $this->value;
-  }
+    public function format(Parser $parser)
+    {
+        return $this->value;
+    }
 }

--- a/src/ast/expr/TernaryExpr.php
+++ b/src/ast/expr/TernaryExpr.php
@@ -25,27 +25,26 @@ use \QuackCompiler\Parser\Parser;
 
 class TernaryExpr implements Expr
 {
-  public $condition;
-  public $then;
-  public $else;
+    public $condition;
+    public $then;
+    public $else;
 
-  public function __construct($condition, $then, $else)
-  {
-    $this->condition = $condition;
-    $this->then = $then;
-    $this->else = $else;
-  }
+    public function __construct($condition, $then, $else)
+    {
+        $this->condition = $condition;
+        $this->then = $then;
+        $this->else = $else;
+    }
 
-  public function format(Parser $parser)
-  {
-    $string_builder = ['('];
-    $string_builder[] = $this->condition->format($parser);
-    $string_builder[] = ' ? ';
-    $string_builder[] = $this->then->format($parser);
-    $string_builder[] = ' : ';
-    $string_builder[] = $this->else->format($parser);
-    $string_builder[] = ')';
-    return implode($string_builder);
-  }
-
+    public function format(Parser $parser)
+    {
+        $string_builder = ['('];
+        $string_builder[] = $this->condition->format($parser);
+        $string_builder[] = ' ? ';
+        $string_builder[] = $this->then->format($parser);
+        $string_builder[] = ' : ';
+        $string_builder[] = $this->else->format($parser);
+        $string_builder[] = ')';
+        return implode($string_builder);
+    }
 }

--- a/src/ast/expr/WhenExpr.php
+++ b/src/ast/expr/WhenExpr.php
@@ -25,14 +25,15 @@ use \QuackCompiler\Parser\Parser;
 
 class WhenExpr implements Expr
 {
-  public $cases;
+    public $cases;
 
-  public function __construct($cases)
-  {
-    $this->cases = $cases;
-  }
+    public function __construct($cases)
+    {
+        $this->cases = $cases;
+    }
 
-  public function format(Parser $_)
-  {
-  }
+    public function format(Parser $_)
+    {
+        throw new \Exception;
+    }
 }

--- a/src/ast/helper/Param.php
+++ b/src/ast/helper/Param.php
@@ -25,30 +25,30 @@ use \QuackCompiler\Parser\Parser;
 
 class Param
 {
-  public $name;
-  public $by_reference;
-  public $ellipsis;
+    public $name;
+    public $by_reference;
+    public $ellipsis;
 
-  public function __construct($name, $by_reference, $ellipsis)
-  {
-    $this->name = $name;
-    $this->by_reference = $by_reference;
-    $this->ellipsis = $ellipsis;
-  }
-
-  public function format(Parser $parser)
-  {
-    $string_builder = [];
-    if ($this->ellipsis) {
-      $string_builder[] = '... ';
+    public function __construct($name, $by_reference, $ellipsis)
+    {
+        $this->name = $name;
+        $this->by_reference = $by_reference;
+        $this->ellipsis = $ellipsis;
     }
 
-    if ($this->by_reference) {
-      $string_builder[] = '*';
+    public function format(Parser $parser)
+    {
+        $string_builder = [];
+        if ($this->ellipsis) {
+            $string_builder[] = '... ';
+        }
+
+        if ($this->by_reference) {
+            $string_builder[] = '*';
+        }
+
+        $string_builder[] = $this->name;
+
+        return implode($string_builder);
     }
-
-    $string_builder[] = $this->name;
-
-    return implode($string_builder);
-  }
 }

--- a/src/ast/stmt/BlockStmt.php
+++ b/src/ast/stmt/BlockStmt.php
@@ -25,30 +25,29 @@ use \QuackCompiler\Parser\Parser;
 
 class BlockStmt implements Stmt
 {
-  public $stmt_list;
+    public $stmt_list;
 
-  public function __construct($stmt_list)
-  {
-    $this->stmt_list = $stmt_list;
-  }
-
-  public function format(Parser $parser)
-  {
-    if (sizeof($this->stmt_list) == 0) {
-      return "[]\n";
+    public function __construct($stmt_list)
+    {
+        $this->stmt_list = $stmt_list;
     }
 
-    $string_builder = ["[\n"];
-    $parser->openScope();
+    public function format(Parser $parser)
+    {
+        if (sizeof($this->stmt_list) == 0) {
+            return "[]\n";
+        }
 
-    foreach ($this->stmt_list as $stmt) {
-      $string_builder[] = $parser->indent() . $stmt->format($parser);
+        $string_builder = ["[\n"];
+        $parser->openScope();
+
+        foreach ($this->stmt_list as $stmt) {
+            $string_builder[] = $parser->indent() . $stmt->format($parser);
+        }
+
+        $string_builder[] = $parser->dedent();
+        $parser->closeScope();
+        $string_builder[] = "]\n";
+        return implode($string_builder);
     }
-
-    $string_builder[] = $parser->dedent();
-    $parser->closeScope();
-    $string_builder[] = "]\n";
-    return implode($string_builder);
-  }
-
 }

--- a/src/ast/stmt/BreakStmt.php
+++ b/src/ast/stmt/BreakStmt.php
@@ -25,24 +25,24 @@ use \QuackCompiler\Parser\Parser;
 
 class BreakStmt implements Stmt
 {
-  public $label;
+    public $label;
 
-  public function __construct($label = NULL)
-  {
-    $this->label = $label;
-  }
-
-  public function format(Parser $parser)
-  {
-    $string_builder = ['break'];
-
-    if (!is_null($this->label)) {
-      $string_builder[] = ' ';
-      $string_builder[] = $this->label->format($parser);
+    public function __construct($label = null)
+    {
+        $this->label = $label;
     }
 
-    $string_builder[] = PHP_EOL;
+    public function format(Parser $parser)
+    {
+        $string_builder = ['break'];
 
-    return implode($string_builder);
-  }
+        if (!is_null($this->label)) {
+            $string_builder[] = ' ';
+            $string_builder[] = $this->label->format($parser);
+        }
+
+        $string_builder[] = PHP_EOL;
+
+        return implode($string_builder);
+    }
 }

--- a/src/ast/stmt/CaseStmt.php
+++ b/src/ast/stmt/CaseStmt.php
@@ -25,19 +25,19 @@ use \QuackCompiler\Parser\Parser;
 
 class CaseStmt implements Stmt
 {
-  public $value;
-  public $body;
-  public $is_else;
+    public $value;
+    public $body;
+    public $is_else;
 
-  public function __construct($value, $body, $is_else = false)
-  {
-    $this->value = $value;
-    $this->body = $body;
-    $this->is_else = $is_else;
-  }
+    public function __construct($value, $body, $is_else = false)
+    {
+        $this->value = $value;
+        $this->body = $body;
+        $this->is_else = $is_else;
+    }
 
-  public function format(Parser $parser)
-  {
-    throw new \Exception('TODO');
-  }
+    public function format(Parser $parser)
+    {
+        throw new \Exception('TODO');
+    }
 }

--- a/src/ast/stmt/ClassStmt.php
+++ b/src/ast/stmt/ClassStmt.php
@@ -25,21 +25,21 @@ use \QuackCompiler\Parser\Parser;
 
 class ClassStmt implements Stmt
 {
-  public $name;
-  public $extends;
-  public $implements;
-  public $body;
+    public $name;
+    public $extends;
+    public $implements;
+    public $body;
 
-  public function __construct($name, $extends, $implements, $body)
-  {
-    $this->name = $name;
-    $this->extends = $extends;
-    $this->implements = $implements;
-    $this->body = $body;
-  }
+    public function __construct($name, $extends, $implements, $body)
+    {
+        $this->name = $name;
+        $this->extends = $extends;
+        $this->implements = $implements;
+        $this->body = $body;
+    }
 
-  public function format(Parser $parser)
-  {
-    throw new \Exception('TODO');
-  }
+    public function format(Parser $parser)
+    {
+        throw new \Exception('TODO');
+    }
 }

--- a/src/ast/stmt/ConstStmt.php
+++ b/src/ast/stmt/ConstStmt.php
@@ -25,21 +25,21 @@ use \QuackCompiler\Parser\Parser;
 
 class ConstStmt implements Stmt
 {
-  public $name;
-  public $value;
+    public $name;
+    public $value;
 
-  public function __construct($name, $value)
-  {
-    $this->name = $name;
-    $this->value = $value;
-  }
+    public function __construct($name, $value)
+    {
+        $this->name = $name;
+        $this->value = $value;
+    }
 
-  public function format(Parser $parser)
-  {
-    $string_builder = ['const '];
-    $string_builder[] = $this->name;
-    $string_builder[] = ' :- ';
-    $string_builder[] = $this->value->format($parser);
-    return implode($string_builder);
-  }
+    public function format(Parser $parser)
+    {
+        $string_builder = ['const '];
+        $string_builder[] = $this->name;
+        $string_builder[] = ' :- ';
+        $string_builder[] = $this->value->format($parser);
+        return implode($string_builder);
+    }
 }

--- a/src/ast/stmt/ContinueStmt.php
+++ b/src/ast/stmt/ContinueStmt.php
@@ -25,24 +25,24 @@ use \QuackCompiler\Parser\Parser;
 
 class ContinueStmt implements Stmt
 {
-  public $label;
+    public $label;
 
-  public function __construct($label = NULL)
-  {
-    $this->label = $label;
-  }
-
-  public function format(Parser $parser)
-  {
-    $string_builder = ['continue'];
-
-    if (!is_null($this->label)) {
-      $string_builder[] = ' ';
-      $string_builder[] = $this->label->format($parser);
+    public function __construct($label = null)
+    {
+        $this->label = $label;
     }
 
-    $string_builder[] = PHP_EOL;
+    public function format(Parser $parser)
+    {
+        $string_builder = ['continue'];
 
-    return implode($string_builder);
-  }
+        if (!is_null($this->label)) {
+            $string_builder[] = ' ';
+            $string_builder[] = $this->label->format($parser);
+        }
+
+        $string_builder[] = PHP_EOL;
+
+        return implode($string_builder);
+    }
 }

--- a/src/ast/stmt/DoWhileStmt.php
+++ b/src/ast/stmt/DoWhileStmt.php
@@ -25,17 +25,17 @@ use \QuackCompiler\Parser\Parser;
 
 class DoWhileStmt implements Stmt
 {
-  public $condition;
-  public $body;
+    public $condition;
+    public $body;
 
-  public function __construct($condition, $body)
-  {
-    $this->condition = $condition;
-    $this->body = $body;
-  }
+    public function __construct($condition, $body)
+    {
+        $this->condition = $condition;
+        $this->body = $body;
+    }
 
-  public function format(Parser $parser)
-  {
-    throw new \Exception('TODO');
-  }
+    public function format(Parser $parser)
+    {
+        throw new \Exception('TODO');
+    }
 }

--- a/src/ast/stmt/ElifStmt.php
+++ b/src/ast/stmt/ElifStmt.php
@@ -25,17 +25,17 @@ use \QuackCompiler\Parser\Parser;
 
 class ElifStmt implements Stmt
 {
-  public $condition;
-  public $body;
+    public $condition;
+    public $body;
 
-  public function __construct($condition, $body)
-  {
-    $this->condition = $condition;
-    $this->body = $body;
-  }
+    public function __construct($condition, $body)
+    {
+        $this->condition = $condition;
+        $this->body = $body;
+    }
 
-  public function format(Parser $parser)
-  {
-    throw new \Exception('TODO. Not implemented');
-  }
+    public function format(Parser $parser)
+    {
+        throw new \Exception('TODO. Not implemented');
+    }
 }

--- a/src/ast/stmt/ExprStmt.php
+++ b/src/ast/stmt/ExprStmt.php
@@ -25,18 +25,17 @@ use \QuackCompiler\Parser\Parser;
 
 class ExprStmt implements Stmt
 {
-  public $expression;
+    public $expression;
 
-  public function __construct($expression)
-  {
-    $this->expression = $expression;
-  }
+    public function __construct($expression)
+    {
+        $this->expression = $expression;
+    }
 
-  public function format(Parser $parser)
-  {
-    $string_builder = [$this->expression->format($parser)];
-    $string_builder[] = ";\n";
-    return implode($string_builder);
-  }
-
+    public function format(Parser $parser)
+    {
+        $string_builder = [$this->expression->format($parser)];
+        $string_builder[] = ";\n";
+        return implode($string_builder);
+    }
 }

--- a/src/ast/stmt/FnStmt.php
+++ b/src/ast/stmt/FnStmt.php
@@ -25,46 +25,47 @@ use \QuackCompiler\Parser\Parser;
 
 class FnStmt implements Stmt
 {
-  public $name;
-  public $by_reference;
-  public $body;
-  public $parameters;
-  public $modifiers = [];
+    public $name;
+    public $by_reference;
+    public $body;
+    public $parameters;
+    public $modifiers = [];
 
-  public function __construct($name, $by_reference, $body, $parameters, $modifiers = [])
-  {
-    $this->name = $name;
-    $this->by_reference = $by_reference;
-    $this->body = $body;
-    $this->parameters = $parameters;
-    $this->modifiers = $modifiers;
-  }
-
-  public function format(Parser $parser)
-  {
-    $string_builder = ['fn '];
-    if ($this->by_reference) {
-      $string_builder[] = '*';
+    public function __construct($name, $by_reference, $body, $parameters, $modifiers = [])
+    {
+        $this->name = $name;
+        $this->by_reference = $by_reference;
+        $this->body = $body;
+        $this->parameters = $parameters;
+        $this->modifiers = $modifiers;
     }
-    $string_builder[] = $this->name;
-    if (sizeof($this->parameters) > 0) {
-      $string_builder[] = ' [';
 
-      for ($i = 0, $l = sizeof($this->parameters); $i < $l; $i++) {
-        $string_builder[] = $this->parameters[$i]->format($parser);
-
-        if ($i !== $l - 1) {
-          $string_builder[] = ', ';
+    public function format(Parser $parser)
+    {
+        $string_builder = ['fn '];
+        if ($this->by_reference) {
+            $string_builder[] = '*';
         }
-      }
 
-      $string_builder[] = '] ';
-    } else {
-      $string_builder[] = '! ';
+        $string_builder[] = $this->name;
+        if (sizeof($this->parameters) > 0) {
+            $string_builder[] = ' [';
+
+            for ($i = 0, $l = sizeof($this->parameters); $i < $l; $i++) {
+                $string_builder[] = $this->parameters[$i]->format($parser);
+
+                if ($i !== $l - 1) {
+                    $string_builder[] = ', ';
+                }
+            }
+
+            $string_builder[] = '] ';
+        } else {
+            $string_builder[] = '! ';
+        }
+
+        $string_builder[] = $this->body->format($parser);
+
+        return implode($string_builder);
     }
-
-    $string_builder[] = $this->body->format($parser);
-
-    return implode($string_builder);
-  }
 }

--- a/src/ast/stmt/ForStmt.php
+++ b/src/ast/stmt/ForStmt.php
@@ -26,24 +26,23 @@ use \QuackCompiler\Parser\Parser;
 
 class ForStmt implements Stmt
 {
-  public $variable;
-  public $from;
-  public $to;
-  public $by;
-  public $body;
+    public $variable;
+    public $from;
+    public $to;
+    public $by;
+    public $body;
 
-  public function __construct($variable, $from, $to, $by, $body)
-  {
-    $this->variable = $variable;
-    $this->from = $from;
-    $this->to = $to;
-    $this->by = $by;
-    $this->body = $body;
-  }
+    public function __construct($variable, $from, $to, $by, $body)
+    {
+        $this->variable = $variable;
+        $this->from = $from;
+        $this->to = $to;
+        $this->by = $by;
+        $this->body = $body;
+    }
 
-  public function format(Parser $parser)
-  {
-    throw new \Exception('TODO');
-  }
-
+    public function format(Parser $parser)
+    {
+        throw new \Exception('TODO');
+    }
 }

--- a/src/ast/stmt/ForeachStmt.php
+++ b/src/ast/stmt/ForeachStmt.php
@@ -26,36 +26,36 @@ use \QuackCompiler\Parser\Parser;
 
 class ForeachStmt implements Stmt
 {
-  public $by_reference;
-  public $alias;
-  public $generator;
-  public $body;
+    public $by_reference;
+    public $alias;
+    public $generator;
+    public $body;
 
-  public function __construct($by_reference, $alias, $generator, $body)
-  {
-    $this->by_reference = $by_reference;
-    $this->alias = $alias;
-    $this->generator = $generator;
-    $this->body = $body;
-  }
-
-  public function format(Parser $parser)
-  {
-    $is_simple = !($this->body instanceof BlockStmt);
-    $string_builder = ['foreach '];
-    $string_builder[] = $this->alias;
-    $string_builder[] = ' in ';
-    $string_builder[] = $this->generator->format($parser);
-    $string_builder[] = ' ';
-
-    if ($is_simple) {
-      $string_builder[] = "\n";
-      $parser->openScope();
-      $string_builder[] = $parser->indent();
-      $parser->closeScope();
+    public function __construct($by_reference, $alias, $generator, $body)
+    {
+        $this->by_reference = $by_reference;
+        $this->alias = $alias;
+        $this->generator = $generator;
+        $this->body = $body;
     }
 
-    $string_builder[] = $this->body->format($parser);
-    return implode($string_builder);
-  }
+    public function format(Parser $parser)
+    {
+        $is_simple = !($this->body instanceof BlockStmt);
+        $string_builder = ['foreach '];
+        $string_builder[] = $this->alias;
+        $string_builder[] = ' in ';
+        $string_builder[] = $this->generator->format($parser);
+        $string_builder[] = ' ';
+
+        if ($is_simple) {
+            $string_builder[] = "\n";
+            $parser->openScope();
+            $string_builder[] = $parser->indent();
+            $parser->closeScope();
+        }
+
+        $string_builder[] = $this->body->format($parser);
+        return implode($string_builder);
+    }
 }

--- a/src/ast/stmt/GlobalStmt.php
+++ b/src/ast/stmt/GlobalStmt.php
@@ -25,18 +25,18 @@ use \QuackCompiler\Parser\Parser;
 
 class GlobalStmt implements Stmt
 {
-  public $name;
+    public $name;
 
-  public function __construct($name)
-  {
-    $this->name = $name;
-  }
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
 
-  public function format(Parser $parser)
-  {
-    $string_builder = ['global '];
-    $string_builder[] = $this->name;
-    $string_builder[] = PHP_EOL;
-    return implode($string_builder);
-  }
+    public function format(Parser $parser)
+    {
+        $string_builder = ['global '];
+        $string_builder[] = $this->name;
+        $string_builder[] = PHP_EOL;
+        return implode($string_builder);
+    }
 }

--- a/src/ast/stmt/GotoStmt.php
+++ b/src/ast/stmt/GotoStmt.php
@@ -25,18 +25,18 @@ use \QuackCompiler\Parser\Parser;
 
 class GotoStmt implements Stmt
 {
-  public $label;
+    public $label;
 
-  public function __construct($label)
-  {
-    $this->label = $label;
-  }
+    public function __construct($label)
+    {
+        $this->label = $label;
+    }
 
-  public function format(Parser $parser)
-  {
-    $string_builder = ['goto '];
-    $string_builder[] = $this->label;
-    $string_builder[] = PHP_EOL;
-    return implode($string_builder);
-  }
+    public function format(Parser $parser)
+    {
+        $string_builder = ['goto '];
+        $string_builder[] = $this->label;
+        $string_builder[] = PHP_EOL;
+        return implode($string_builder);
+    }
 }

--- a/src/ast/stmt/IfStmt.php
+++ b/src/ast/stmt/IfStmt.php
@@ -26,34 +26,34 @@ use \QuackCompiler\Parser\Parser;
 
 class IfStmt implements Stmt
 {
-  public $condition;
-  public $body;
-  public $elif;
-  public $else;
+    public $condition;
+    public $body;
+    public $elif;
+    public $else;
 
-  public function __construct($condition, $body, $elif, $else)
-  {
-    $this->condition = $condition;
-    $this->body = $body;
-    $this->elif = $elif;
-    $this->else = $else;
-  }
-
-  public function format(Parser $parser)
-  {
-    $is_simple = !($this->body instanceof BlockStmt);
-    $string_builder = ['if '];
-    $string_builder[] = $this->condition->format($parser);
-    $string_builder[] = ' ';
-
-    if ($is_simple) {
-      $string_builder[] = "\n";
-      $parser->openScope();
-      $string_builder[] = $parser->indent();
-      $parser->closeScope();
+    public function __construct($condition, $body, $elif, $else)
+    {
+        $this->condition = $condition;
+        $this->body = $body;
+        $this->elif = $elif;
+        $this->else = $else;
     }
 
-    $string_builder[] = $this->body->format($parser);
-    return implode($string_builder);
-  }
+    public function format(Parser $parser)
+    {
+        $is_simple = !($this->body instanceof BlockStmt);
+        $string_builder = ['if '];
+        $string_builder[] = $this->condition->format($parser);
+        $string_builder[] = ' ';
+
+        if ($is_simple) {
+            $string_builder[] = "\n";
+            $parser->openScope();
+            $string_builder[] = $parser->indent();
+            $parser->closeScope();
+        }
+
+        $string_builder[] = $this->body->format($parser);
+        return implode($string_builder);
+    }
 }

--- a/src/ast/stmt/IntfStmt.php
+++ b/src/ast/stmt/IntfStmt.php
@@ -25,19 +25,19 @@ use \QuackCompiler\Parser\Parser;
 
 class IntfStmt implements Stmt
 {
-  public $name;
-  public $extends;
-  public $body;
+    public $name;
+    public $extends;
+    public $body;
 
-  public function __construct($name, $extends, $body)
-  {
-    $this->name = $name;
-    $this->extends = $extends;
-    $this->body = $body;
-  }
+    public function __construct($name, $extends, $body)
+    {
+        $this->name = $name;
+        $this->extends = $extends;
+        $this->body = $body;
+    }
 
-  public function format(Parser $parser)
-  {
-    throw new \Exception('TODO');
-  }
+    public function format(Parser $parser)
+    {
+        throw new \Exception('TODO');
+    }
 }

--- a/src/ast/stmt/LabelStmt.php
+++ b/src/ast/stmt/LabelStmt.php
@@ -25,18 +25,18 @@ use \QuackCompiler\Parser\Parser;
 
 class LabelStmt implements Stmt
 {
-  public $label;
+    public $label;
 
-  public function __construct($label)
-  {
-    $this->label = $label;
-  }
+    public function __construct($label)
+    {
+        $this->label = $label;
+    }
 
-  public function format(Parser $parser)
-  {
-    $string_builder = [':- '];
-    $string_builder[] = $this->label;
-    $string_builder[] = PHP_EOL;
-    return implode($string_builder);
-  }
+    public function format(Parser $parser)
+    {
+        $string_builder = [':- '];
+        $string_builder[] = $this->label;
+        $string_builder[] = PHP_EOL;
+        return implode($string_builder);
+    }
 }

--- a/src/ast/stmt/LetStmt.php
+++ b/src/ast/stmt/LetStmt.php
@@ -25,17 +25,17 @@ use \QuackCompiler\Parser\Parser;
 
 class LetStmt implements Stmt
 {
-  public $name;
-  public $value;
+    public $name;
+    public $value;
 
-  public function __construct($name, $value)
-  {
-    $this->name = $name;
-    $this->value = $value;
-  }
+    public function __construct($name, $value)
+    {
+        $this->name = $name;
+        $this->value = $value;
+    }
 
-  public function format(Parser $parser)
-  {
-    throw new \Exception('TODO');
-  }
+    public function format(Parser $parser)
+    {
+        throw new \Exception('TODO');
+    }
 }

--- a/src/ast/stmt/ModuleStmt.php
+++ b/src/ast/stmt/ModuleStmt.php
@@ -25,18 +25,18 @@ use \QuackCompiler\Parser\Parser;
 
 class ModuleStmt implements Stmt
 {
-  public $qualified_name;
+    public $qualified_name;
 
-  public function __construct($qualified_name)
-  {
-    $this->qualified_name = $qualified_name;
-  }
+    public function __construct($qualified_name)
+    {
+        $this->qualified_name = $qualified_name;
+    }
 
-  public function format(Parser $parser)
-  {
-    $string_builder = ['module '];
-    $string_builder[] = implode('.', $this->qualified_name);
-    $string_builder[] = PHP_EOL;
-    return implode($string_builder);
-  }
+    public function format(Parser $parser)
+    {
+        $string_builder = ['module '];
+        $string_builder[] = implode('.', $this->qualified_name);
+        $string_builder[] = PHP_EOL;
+        return implode($string_builder);
+    }
 }

--- a/src/ast/stmt/OpenStmt.php
+++ b/src/ast/stmt/OpenStmt.php
@@ -25,29 +25,29 @@ use \QuackCompiler\Parser\Parser;
 
 class OpenStmt implements Stmt
 {
-  public $module;
-  public $alias;
-  public $type;
+    public $module;
+    public $alias;
+    public $type;
 
-  public function __construct($module, $alias = NULL, $type = NULL)
-  {
-    $this->module = $module;
-    $this->alias = $alias;
-    $this->type = $type;
-  }
-
-  public function format(Parser $parser)
-  {
-    $string_builder = ['open '];
-    $string_builder[] = implode('.', $this->module);
-
-    if (!is_null($this->alias)) {
-      $string_builder[] = ' as ';
-      $string_builder[] = $this->alias;
+    public function __construct($module, $alias = null, $type = null)
+    {
+        $this->module = $module;
+        $this->alias = $alias;
+        $this->type = $type;
     }
 
-    $string_builder[] = PHP_EOL;
+    public function format(Parser $parser)
+    {
+        $string_builder = ['open '];
+        $string_builder[] = implode('.', $this->module);
 
-    return implode($string_builder);
-  }
+        if (!is_null($this->alias)) {
+            $string_builder[] = ' as ';
+            $string_builder[] = $this->alias;
+        }
+
+        $string_builder[] = PHP_EOL;
+
+        return implode($string_builder);
+    }
 }

--- a/src/ast/stmt/PieceStmt.php
+++ b/src/ast/stmt/PieceStmt.php
@@ -25,17 +25,17 @@ use \QuackCompiler\Parser\Parser;
 
 class PieceStmt implements Stmt
 {
-  public $name;
-  public $body;
+    public $name;
+    public $body;
 
-  public function __construct($name, $body)
-  {
-    $this->name = $name;
-    $this->body = $body;
-  }
+    public function __construct($name, $body)
+    {
+        $this->name = $name;
+        $this->body = $body;
+    }
 
-  public function format(Parser $parser)
-  {
-    throw new \Exception('TODO');
-  }
+    public function format(Parser $parser)
+    {
+        throw new \Exception('TODO');
+    }
 }

--- a/src/ast/stmt/PrintStmt.php
+++ b/src/ast/stmt/PrintStmt.php
@@ -25,19 +25,19 @@ use \QuackCompiler\Parser\Parser;
 
 class PrintStmt implements Stmt
 {
-  public $expression;
+    public $expression;
 
-  public function __construct($expression)
-  {
-    $this->expression = $expression;
-  }
+    public function __construct($expression)
+    {
+        $this->expression = $expression;
+    }
 
-  public function format(Parser $parser)
-  {
-    $string_builder = ['print '];
-    $string_builder[] = $this->expression->format($parser);
-    $string_builder[] = PHP_EOL;
+    public function format(Parser $parser)
+    {
+        $string_builder = ['print '];
+        $string_builder[] = $this->expression->format($parser);
+        $string_builder[] = PHP_EOL;
 
-    return implode($string_builder);
-  }
+        return implode($string_builder);
+    }
 }

--- a/src/ast/stmt/PropertyStmt.php
+++ b/src/ast/stmt/PropertyStmt.php
@@ -25,19 +25,19 @@ use \QuackCompiler\Parser\Parser;
 
 class PropertyStmt implements Stmt
 {
-  public $name;
-  public $value;
-  public $modifiers;
+    public $name;
+    public $value;
+    public $modifiers;
 
-  public function __construct($name, $value, $modifiers = [])
-  {
-    $this->name = $name;
-    $this->value = $value;
-    $this->modifiers = $modifiers;
-  }
+    public function __construct($name, $value, $modifiers = [])
+    {
+        $this->name = $name;
+        $this->value = $value;
+        $this->modifiers = $modifiers;
+    }
 
-  public function format(Parser $parser)
-  {
-    throw new TodoException;
-  }
+    public function format(Parser $parser)
+    {
+        throw new TodoException;
+    }
 }

--- a/src/ast/stmt/RaiseStmt.php
+++ b/src/ast/stmt/RaiseStmt.php
@@ -25,19 +25,19 @@ use \QuackCompiler\Parser\Parser;
 
 class RaiseStmt implements Stmt
 {
-  public $expression;
+    public $expression;
 
-  public function __construct($expression)
-  {
-    $this->expression = $expression;
-  }
+    public function __construct($expression)
+    {
+        $this->expression = $expression;
+    }
 
-  public function format(Parser $parser)
-  {
-    $string_builder = ['raise'];
-    $string_builder[] = ' ';
-    $string_builder[] = $this->expression->format($parser);
-    $string_builder[] = PHP_EOL;
-    return implode($string_builder);
-  }
+    public function format(Parser $parser)
+    {
+        $string_builder = ['raise'];
+        $string_builder[] = ' ';
+        $string_builder[] = $this->expression->format($parser);
+        $string_builder[] = PHP_EOL;
+        return implode($string_builder);
+    }
 }

--- a/src/ast/stmt/RescueStmt.php
+++ b/src/ast/stmt/RescueStmt.php
@@ -25,19 +25,19 @@ use \QuackCompiler\Parser\Parser;
 
 class RescueStmt implements Stmt
 {
-  public $exception_class;
-  public $variable;
-  public $body;
+    public $exception_class;
+    public $variable;
+    public $body;
 
-  public function __construct($exception_class, $variable, $body)
-  {
-    $this->exception_class = $exception_class;
-    $this->variable = $variable;
-    $this->body = $body;
-  }
+    public function __construct($exception_class, $variable, $body)
+    {
+        $this->exception_class = $exception_class;
+        $this->variable = $variable;
+        $this->body = $body;
+    }
 
-  public function format(Parser $parser)
-  {
-    throw new \Exception('TODO');
-  }
+    public function format(Parser $parser)
+    {
+        throw new \Exception('TODO');
+    }
 }

--- a/src/ast/stmt/ReturnStmt.php
+++ b/src/ast/stmt/ReturnStmt.php
@@ -25,24 +25,23 @@ use \QuackCompiler\Parser\Parser;
 
 class ReturnStmt implements Stmt
 {
-  public $expression;
+    public $expression;
 
-  public function __construct($expression = NULL)
-  {
-    $this->expression = $expression;
-  }
-
-  public function format(Parser $parser)
-  {
-    $string_builder = ['<<<'];
-
-    if (!is_null($this->expression)) {
-      $string_builder[] = ' ';
-      $string_builder[] = $this->expression->format($parser);
-      $string_builder[] = PHP_EOL;
+    public function __construct($expression = null)
+    {
+        $this->expression = $expression;
     }
 
-    return implode($string_builder);
-  }
+    public function format(Parser $parser)
+    {
+        $string_builder = ['<<<'];
 
+        if (!is_null($this->expression)) {
+            $string_builder[] = ' ';
+            $string_builder[] = $this->expression->format($parser);
+            $string_builder[] = PHP_EOL;
+        }
+
+        return implode($string_builder);
+    }
 }

--- a/src/ast/stmt/Stmt.php
+++ b/src/ast/stmt/Stmt.php
@@ -23,4 +23,6 @@ namespace QuackCompiler\Ast\Stmt;
 
 use QuackCompiler\Ast\Node;
 
-interface Stmt extends Node {}
+interface Stmt extends Node
+{
+}

--- a/src/ast/stmt/StructStmt.php
+++ b/src/ast/stmt/StructStmt.php
@@ -25,19 +25,19 @@ use \QuackCompiler\Parser\Parser;
 
 class StructStmt implements Stmt
 {
-  public $name;
-  public $interfaces;
-  public $body;
+    public $name;
+    public $interfaces;
+    public $body;
 
-  public function __construct($name, $interfaces, $body)
-  {
-    $this->name = $name;
-    $this->interfaces = $interfaces;
-    $this->body = $body;
-  }
+    public function __construct($name, $interfaces, $body)
+    {
+        $this->name = $name;
+        $this->interfaces = $interfaces;
+        $this->body = $body;
+    }
 
-  public function format(Parser $parser)
-  {
-    throw new \Exception('TODO');
-  }
+    public function format(Parser $parser)
+    {
+        throw new \Exception('TODO');
+    }
 }

--- a/src/ast/stmt/SwitchStmt.php
+++ b/src/ast/stmt/SwitchStmt.php
@@ -25,17 +25,17 @@ use \QuackCompiler\Parser\Parser;
 
 class SwitchStmt implements Stmt
 {
-  public $value;
-  public $cases;
+    public $value;
+    public $cases;
 
-  public function __construct($value, $cases)
-  {
-    $this->value = $value;
-    $this->cases = $cases;
-  }
+    public function __construct($value, $cases)
+    {
+        $this->value = $value;
+        $this->cases = $cases;
+    }
 
-  public function format(Parser $parser)
-  {
-    throw new \Exception('TODO');
-  }
+    public function format(Parser $parser)
+    {
+        throw new \Exception('TODO');
+    }
 }

--- a/src/ast/stmt/TryStmt.php
+++ b/src/ast/stmt/TryStmt.php
@@ -25,19 +25,19 @@ use \QuackCompiler\Parser\Parser;
 
 class TryStmt implements Stmt
 {
-  public $try;
-  public $rescues;
-  public $finally;
+    public $try;
+    public $rescues;
+    public $finally;
 
-  public function __construct($try, $rescues, $finally)
-  {
-    $this->try = $try;
-    $this->rescues = $rescues;
-    $this->finally = $finally;
-  }
+    public function __construct($try, $rescues, $finally)
+    {
+        $this->try = $try;
+        $this->rescues = $rescues;
+        $this->finally = $finally;
+    }
 
-  public function format(Parser $parser)
-  {
-    throw new \Exception('TODO');
-  }
+    public function format(Parser $parser)
+    {
+        throw new \Exception('TODO');
+    }
 }

--- a/src/ast/stmt/WhileStmt.php
+++ b/src/ast/stmt/WhileStmt.php
@@ -26,31 +26,30 @@ use \QuackCompiler\Parser\Parser;
 
 class WhileStmt implements Stmt
 {
-  public $condition;
-  public $body;
+    public $condition;
+    public $body;
 
-  public function __construct($condition, $body)
-  {
-    $this->condition = $condition;
-    $this->body = $body;
-  }
-
-  public function format(Parser $parser)
-  {
-    $is_simple = !($this->body instanceof BlockStmt);
-    $string_builder = ['while '];
-    $string_builder[] = $this->condition->format($parser);
-    $string_builder[] = ' ';
-
-    if ($is_simple) {
-      $string_builder[] = "\n";
-      $parser->openScope();
-      $string_builder[] = $parser->indent();
-      $parser->closeScope();
+    public function __construct($condition, $body)
+    {
+        $this->condition = $condition;
+        $this->body = $body;
     }
 
-    $string_builder[] = $this->body->format($parser);
-    return implode($string_builder);
-  }
+    public function format(Parser $parser)
+    {
+        $is_simple = !($this->body instanceof BlockStmt);
+        $string_builder = ['while '];
+        $string_builder[] = $this->condition->format($parser);
+        $string_builder[] = ' ';
 
+        if ($is_simple) {
+            $string_builder[] = "\n";
+            $parser->openScope();
+            $string_builder[] = $parser->indent();
+            $parser->closeScope();
+        }
+
+        $string_builder[] = $this->body->format($parser);
+        return implode($string_builder);
+    }
 }

--- a/src/lexer/Lexer.php
+++ b/src/lexer/Lexer.php
@@ -23,159 +23,159 @@ namespace QuackCompiler\Lexer;
 
 abstract class Lexer
 {
-  const EOF      = -1;
-  const EOF_TYPE =  0;
+    const EOF      = -1;
+    const EOF_TYPE =  0;
 
-  public $input;
-  public $position = 0;
-  public $peek;
+    public $input;
+    public $position = 0;
+    public $peek;
 
-  protected $words = [];
+    protected $words = [];
 
-  public $symbol_table;
+    public $symbol_table;
 
-  public function __construct($input)
-  {
-    $this->size = strlen($input);
+    public function __construct($input)
+    {
+        $this->size = strlen($input);
 
-    if ($this->size === 0) {
-      exit;
+        if ($this->size === 0) {
+            exit;
+        }
+
+        $this->symbol_table = new SymbolTable;
+        $this->input = $input;
+        $this->peek  = $input[0];
+
+        // Reserve keywords
+        $this->reserve(new Word(Tag::T_TRUE, "true"));
+        $this->reserve(new Word(Tag::T_FALSE, "false"));
+        $this->reserve(new Word(Tag::T_LET, "let"));
+        $this->reserve(new Word(Tag::T_IF, "if"));
+        $this->reserve(new Word(Tag::T_FOR, "for"));
+        $this->reserve(new Word(Tag::T_WHILE, "while"));
+        $this->reserve(new Word(Tag::T_DO, "do"));
+        $this->reserve(new Word(Tag::T_STRUCT, "struct"));
+        $this->reserve(new Word(Tag::T_INIT, "init"));
+        $this->reserve(new Word(Tag::T_SELF, "self"));
+        $this->reserve(new Word(Tag::T_MODULE, "module"));
+        $this->reserve(new Word(Tag::T_CLASS, "class"));
+        $this->reserve(new Word(Tag::T_GOTO, "goto"));
+        $this->reserve(new Word(Tag::T_FOREACH, "foreach"));
+        $this->reserve(new Word(Tag::T_IN, "in"));
+        $this->reserve(new Word(Tag::T_MOD, "mod"));
+        $this->reserve(new Word(Tag::T_WHERE, "where"));
+        $this->reserve(new Word(Tag::T_CONST, "const"));
+        $this->reserve(new Word(Tag::T_NIL, "nil"));
+        $this->reserve(new Word(Tag::T_OPEN, "open"));
+        $this->reserve(new Word(Tag::T_GLOBAL, "global"));
+        $this->reserve(new Word(Tag::T_AS, "as"));
+        $this->reserve(new Word(Tag::T_ENUM, "enum"));
+        $this->reserve(new Word(Tag::T_CONTINUE, "continue"));
+        $this->reserve(new Word(Tag::T_SWITCH, "switch"));
+        $this->reserve(new Word(Tag::T_BREAK, "break"));
+        $this->reserve(new Word(Tag::T_AND, "and"));
+        $this->reserve(new Word(Tag::T_OR, "or"));
+        $this->reserve(new Word(Tag::T_XOR, "xor"));
+        $this->reserve(new Word(Tag::T_TRY, "try"));
+        $this->reserve(new Word(Tag::T_RESCUE, "rescue"));
+        $this->reserve(new Word(Tag::T_FINALLY, "finally"));
+        $this->reserve(new Word(Tag::T_RAISE, "raise"));
+        $this->reserve(new Word(Tag::T_ELIF, "elif"));
+        $this->reserve(new Word(Tag::T_ELSE, "else"));
+        $this->reserve(new Word(Tag::T_CASE, "case"));
+        $this->reserve(new Word(Tag::T_SUPER, "super"));
+        $this->reserve(new Word(Tag::T_IS, "is"));
+        $this->reserve(new Word(Tag::T_DERIVING, "deriving"));
+        $this->reserve(new Word(Tag::T_PRINT, "print"));
+        $this->reserve(new Word(Tag::T_NOT, "not"));
+        $this->reserve(new Word(Tag::T_FN, "fn"));
+        $this->reserve(new Word(Tag::T_REQUIRE, "require"));
+        $this->reserve(new Word(Tag::T_INCLUDE, "include"));
+        $this->reserve(new Word(Tag::T_ONCE, "once"));
+        $this->reserve(new Word(Tag::T_THEN, "then"));
+        $this->reserve(new Word(Tag::T_BEGIN, "begin"));
+        $this->reserve(new Word(Tag::T_END, "end"));
+        $this->reserve(new Word(Tag::T_FROM, "from"));
+        $this->reserve(new Word(Tag::T_TO, "to"));
+        $this->reserve(new Word(Tag::T_BY, "by"));
+        $this->reserve(new Word(Tag::T_WHEN, "when"));
+        $this->reserve(new Word(Tag::T_UNLESS, "unless"));
     }
 
-    $this->symbol_table = new SymbolTable;
-    $this->input = $input;
-    $this->peek  = $input[0];
-
-    // Reserve keywords
-    $this->reserve(new Word(Tag::T_TRUE, "true"));
-    $this->reserve(new Word(Tag::T_FALSE, "false"));
-    $this->reserve(new Word(Tag::T_LET, "let"));
-    $this->reserve(new Word(Tag::T_IF, "if"));
-    $this->reserve(new Word(Tag::T_FOR, "for"));
-    $this->reserve(new Word(Tag::T_WHILE, "while"));
-    $this->reserve(new Word(Tag::T_DO, "do"));
-    $this->reserve(new Word(Tag::T_STRUCT, "struct"));
-    $this->reserve(new Word(Tag::T_INIT, "init"));
-    $this->reserve(new Word(Tag::T_SELF, "self"));
-    $this->reserve(new Word(Tag::T_MODULE, "module"));
-    $this->reserve(new Word(Tag::T_CLASS, "class"));
-    $this->reserve(new Word(Tag::T_GOTO, "goto"));
-    $this->reserve(new Word(Tag::T_FOREACH, "foreach"));
-    $this->reserve(new Word(Tag::T_IN, "in"));
-    $this->reserve(new Word(Tag::T_MOD, "mod"));
-    $this->reserve(new Word(Tag::T_WHERE, "where"));
-    $this->reserve(new Word(Tag::T_CONST, "const"));
-    $this->reserve(new Word(Tag::T_NIL, "nil"));
-    $this->reserve(new Word(Tag::T_OPEN, "open"));
-    $this->reserve(new Word(Tag::T_GLOBAL, "global"));
-    $this->reserve(new Word(Tag::T_AS, "as"));
-    $this->reserve(new Word(Tag::T_ENUM, "enum"));
-    $this->reserve(new Word(Tag::T_CONTINUE, "continue"));
-    $this->reserve(new Word(Tag::T_SWITCH, "switch"));
-    $this->reserve(new Word(Tag::T_BREAK, "break"));
-    $this->reserve(new Word(Tag::T_AND, "and"));
-    $this->reserve(new Word(Tag::T_OR, "or"));
-    $this->reserve(new Word(Tag::T_XOR, "xor"));
-    $this->reserve(new Word(Tag::T_TRY, "try"));
-    $this->reserve(new Word(Tag::T_RESCUE, "rescue"));
-    $this->reserve(new Word(Tag::T_FINALLY, "finally"));
-    $this->reserve(new Word(Tag::T_RAISE, "raise"));
-    $this->reserve(new Word(Tag::T_ELIF, "elif"));
-    $this->reserve(new Word(Tag::T_ELSE, "else"));
-    $this->reserve(new Word(Tag::T_CASE, "case"));
-    $this->reserve(new Word(Tag::T_SUPER, "super"));
-    $this->reserve(new Word(Tag::T_IS, "is"));
-    $this->reserve(new Word(Tag::T_DERIVING, "deriving"));
-    $this->reserve(new Word(Tag::T_PRINT, "print"));
-    $this->reserve(new Word(Tag::T_NOT, "not"));
-    $this->reserve(new Word(Tag::T_FN, "fn"));
-    $this->reserve(new Word(Tag::T_REQUIRE, "require"));
-    $this->reserve(new Word(Tag::T_INCLUDE, "include"));
-    $this->reserve(new Word(Tag::T_ONCE, "once"));
-    $this->reserve(new Word(Tag::T_THEN, "then"));
-    $this->reserve(new Word(Tag::T_BEGIN, "begin"));
-    $this->reserve(new Word(Tag::T_END, "end"));
-    $this->reserve(new Word(Tag::T_FROM, "from"));
-    $this->reserve(new Word(Tag::T_TO, "to"));
-    $this->reserve(new Word(Tag::T_BY, "by"));
-    $this->reserve(new Word(Tag::T_WHEN, "when"));
-    $this->reserve(new Word(Tag::T_UNLESS, "unless"));
-  }
-
-  private function reserve(Word $t)
-  {
-    $this->words[$t->lexeme] = $t;
-  }
-
-  protected function isEnd()
-  {
-    return $this->position >= $this->size;
-  }
-
-  public function rewind()
-  {
-    if ($this->size === 0) {
-      exit;
+    private function reserve(Word $t)
+    {
+        $this->words[$t->lexeme] = $t;
     }
 
-    $this->position = 0;
-    $this->peek = $this->input[0];
-  }
-
-  public function consume($n = 1)
-  {
-    $this->position += $n;
-    $this->peek = $this->isEnd()
-      ? /* then      */ self::EOF
-      : /* otherwise */ $this->input[$this->position];
-  }
-
-  public function preview($n = 1)
-  {
-    $next = $this->position + $n;
-
-    return $next >= $this->size
-      ? /* then      */ self::EOF
-      : /* otherwise */ $this->input[$next];
-  }
-
-  public function previous()
-  {
-    $previous = $this->position - 1;
-    return $previous < 0
-      ? /* then      */ NULL
-      : /* otherwise */ $this->input[$previous];
-  }
-
-  public function matches($string)
-  {
-    $len = strlen($string);
-
-    for ($i = 0; $i < $len; $i++) {
-      if ($this->preview($i) !== $string[$i]) {
-        return false;
-      }
+    protected function isEnd()
+    {
+        return $this->position >= $this->size;
     }
 
-    return true;
-  }
+    public function rewind()
+    {
+        if ($this->size === 0) {
+            exit;
+        }
 
-  protected function getWord($word)
-  {
-    return isset($this->words[$word])
-      ? $this->words[$word]
-      : NULL;
-  }
+        $this->position = 0;
+        $this->peek = $this->input[0];
+    }
 
-  public function is($symbol)
-  {
-    return $this->peek === $symbol;
-  }
+    public function consume($n = 1)
+    {
+        $this->position += $n;
+        $this->peek = $this->isEnd()
+            ? self::EOF
+            : $this->input[$this->position];
+    }
 
-  public function isNot($symbol)
-  {
-    return $this->peek !== $symbol;
-  }
+    public function preview($n = 1)
+    {
+        $next = $this->position + $n;
 
-  public abstract function nextToken();
+        return $next >= $this->size
+            ? self::EOF
+            : $this->input[$next];
+    }
+
+    public function previous()
+    {
+        $previous = $this->position - 1;
+        return $previous < 0
+            ? null
+            : $this->input[$previous];
+    }
+
+    public function matches($string)
+    {
+        $len = strlen($string);
+
+        for ($i = 0; $i < $len; $i++) {
+            if ($this->preview($i) !== $string[$i]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected function getWord($word)
+    {
+        return isset($this->words[$word])
+            ? $this->words[$word]
+            : null;
+    }
+
+    public function is($symbol)
+    {
+        return $this->peek === $symbol;
+    }
+
+    public function isNot($symbol)
+    {
+        return $this->peek !== $symbol;
+    }
+
+    abstract public function nextToken();
 }

--- a/src/lexer/Lexer.php
+++ b/src/lexer/Lexer.php
@@ -86,7 +86,6 @@ abstract class Lexer
         $this->reserve(new Word(Tag::T_SUPER, "super"));
         $this->reserve(new Word(Tag::T_IS, "is"));
         $this->reserve(new Word(Tag::T_DERIVING, "deriving"));
-        $this->reserve(new Word(Tag::T_PRINT, "print"));
         $this->reserve(new Word(Tag::T_NOT, "not"));
         $this->reserve(new Word(Tag::T_FN, "fn"));
         $this->reserve(new Word(Tag::T_REQUIRE, "require"));

--- a/src/lexer/SymbolDecypher.php
+++ b/src/lexer/SymbolDecypher.php
@@ -23,64 +23,67 @@ namespace QuackCompiler\Lexer;
 
 class SymbolDecypher
 {
-  public static function add($x, $y) { return $x + $y; }
+    public static function add($x, $y)
+    {
+        return $x + $y;
+    }
 
-  public static function __callStatic($method, $args)
-  {
-    $context = &$args[0];
+    public static function __callStatic($method, $args)
+    {
+        $context = &$args[0];
 
-    switch ($method) {
-      case '<':
-        return static::tryMatch($context, ['<<<', '<<', '<>', '<=']);
-      case '>':
-        return static::tryMatch($context, ['>>>', '>=', '>>']);
-      case ':':
-        return static::tryMatch($context, [':-']);
-      case '+':
-        return static::tryMatch($context, ['+++', '++']);
-      case '?':
-        return static::tryMatch($context, ['?.', '?:', '??']);
-      case '*':
-        return static::tryMatch($context, ['**']);
-      case '=':
-        return static::tryMatch($context, ['=~']);
-      case '|':
-        return static::tryMatch($context, ['|>']);
-      case '^':
-        return static::tryMatch($context, ['^^']);
-      case '-':
-        return static::tryMatch($context, ['->']);
-      case '&':
-        if (ctype_digit($context->preview())) {
-          $context->consume();
-          $param_index = $context->digit()->getPointer();
-          return new Token(Tag::T_PARAM, $param_index);
+        switch ($method) {
+            case '<':
+                return static::tryMatch($context, ['<<<', '<<', '<>', '<=']);
+            case '>':
+                return static::tryMatch($context, ['>>>', '>=', '>>']);
+            case ':':
+                return static::tryMatch($context, [':-']);
+            case '+':
+                return static::tryMatch($context, ['+++', '++']);
+            case '?':
+                return static::tryMatch($context, ['?.', '?:', '??']);
+            case '*':
+                return static::tryMatch($context, ['**']);
+            case '=':
+                return static::tryMatch($context, ['=~']);
+            case '|':
+                return static::tryMatch($context, ['|>']);
+            case '^':
+                return static::tryMatch($context, ['^^']);
+            case '-':
+                return static::tryMatch($context, ['->']);
+            case '&':
+                if (ctype_digit($context->preview())) {
+                    $context->consume();
+                    $param_index = $context->digit()->getPointer();
+                    return new Token(Tag::T_PARAM, $param_index);
+                }
+
+                return static::tryMatch($context, ['&{', '&(']);
+            case '.':
+                return static::tryMatch($context, ['...', '..']);
+            default:
+                return static::fetch($context, $context->peek);
+        }
+    }
+
+    private static function tryMatch(&$context, $operator_list)
+    {
+        foreach ($operator_list as $operator) {
+            if ($context->matches($operator)) {
+                return static::fetch($context, $operator);
+            }
         }
 
-        return static::tryMatch($context, ['&{', '&(']);
-      case '.':
-        return static::tryMatch($context, ['...', '..']);
-      default:
         return static::fetch($context, $context->peek);
     }
-  }
 
-  private static function tryMatch(&$context, $operator_list)
-  {
-    foreach ($operator_list as $operator) {
-      if ($context->matches($operator)) {
-        return static::fetch($context, $operator);
-      }
+    private static function fetch($context, $symbol)
+    {
+        $size = strlen($symbol);
+        $context->consume($size);
+        $context->column += $size;
+        return new Token($symbol);
     }
-
-    return static::fetch($context, $context->peek);
-  }
-
-  private static function fetch($context, $symbol)
-  {
-    $size = strlen($symbol);
-    $context->consume($size);
-    $context->column += $size;
-    return new Token($symbol);
-  }
 }

--- a/src/lexer/SymbolTable.php
+++ b/src/lexer/SymbolTable.php
@@ -23,26 +23,26 @@ namespace QuackCompiler\Lexer;
 
 class SymbolTable
 {
-  private $table   = [];
-  private $counter =  0;
+    private $table   = [];
+    private $counter =  0;
 
-  public function add(&$value)
-  {
-    $pointer = $this->counter;
-    $this->table[$pointer] = $value;
-    $this->counter++;
-    return $pointer;
-  }
-
-  public function get($pointer)
-  {
-    return $this->table[$pointer];
-  }
-
-  public function iterator()
-  {
-    foreach ($this->table as $key => $value) {
-      yield $key => $value;
+    public function add(&$value)
+    {
+        $pointer = $this->counter;
+        $this->table[$pointer] = $value;
+        $this->counter++;
+        return $pointer;
     }
-  }
+
+    public function get($pointer)
+    {
+        return $this->table[$pointer];
+    }
+
+    public function iterator()
+    {
+        foreach ($this->table as $key => $value) {
+            yield $key => $value;
+        }
+    }
 }

--- a/src/lexer/Tag.php
+++ b/src/lexer/Tag.php
@@ -25,208 +25,209 @@ use \ReflectionClass;
 
 class Tag
 {
-  /* Constructions */
-  const T_IDENT = 257;
-  const T_INTEGER = 258;
-  const T_DOUBLE = 400;
-  const T_SEMANTIC_COMMENT = 259;
-  const T_STRING = 600;
-  const T_ATOM = 601;
-  const T_PARAM = 1000;
+    /* Constructions */
+    const T_IDENT = 257;
+    const T_INTEGER = 258;
+    const T_DOUBLE = 400;
+    const T_SEMANTIC_COMMENT = 259;
+    const T_STRING = 600;
+    const T_ATOM = 601;
+    const T_PARAM = 1000;
 
-  /* Keywords */
-  const T_TRUE = 260;
-  const T_FALSE = 261;
-  const T_IF = 262;
-  const T_FOR = 263;
-  const T_WHILE = 264;
-  const T_DO = 265;
-  const T_STRUCT = 266;
-  const T_INIT = 267;
-  const T_SELF = 268;
-  const T_MODULE = 269;
-  const T_CLASS = 270;
-  const T_NIL = 272;
-  const T_LET = 273;
-  const T_CONST = 274;
-  const T_GOTO = 275;
-  const T_WHERE = 280;
-  const T_FOREACH = 281;
-  const T_IN = 284;
-  const T_OPEN = 502;
-  const T_GLOBAL = 503;
-  const T_AS = 504;
-  const T_ENUM = 506;
-  const T_CONTINUE = 508;
-  const T_SWITCH = 509;
-  const T_BREAK = 510;
-  const T_AND = 511;
-  const T_OR = 512;
-  const T_XOR = 513;
-  const T_EXTENSION = 800;
-  const T_PRINT = 801;
-  const T_TRY = 515;
-  const T_RESCUE = 516;
-  const T_FINALLY = 517;
-  const T_RAISE = 518;
-  const T_ELIF = 520;
-  const T_ELSE = 521;
-  const T_CASE = 522;
-  const T_SUPER = 525;
-  const T_IS = 527;
-  const T_DERIVING = 529;
-  const T_MOD = 292;
-  const T_NOT = 293;
-  const T_FN = 294;
-  const T_INCLUDE = 295;
-  const T_REQUIRE = 296;
-  const T_ONCE = 297;
-  const T_THEN = 300;
-  const T_BEGIN = 301;
-  const T_END = 302;
-  const T_FROM = 303;
-  const T_TO = 304;
-  const T_BY = 305;
-  const T_WHEN = 306;
-  const T_UNLESS = 307;
+    /* Keywords */
+    const T_TRUE = 260;
+    const T_FALSE = 261;
+    const T_IF = 262;
+    const T_FOR = 263;
+    const T_WHILE = 264;
+    const T_DO = 265;
+    const T_STRUCT = 266;
+    const T_INIT = 267;
+    const T_SELF = 268;
+    const T_MODULE = 269;
+    const T_CLASS = 270;
+    const T_NIL = 272;
+    const T_LET = 273;
+    const T_CONST = 274;
+    const T_GOTO = 275;
+    const T_WHERE = 280;
+    const T_FOREACH = 281;
+    const T_IN = 284;
+    const T_OPEN = 502;
+    const T_GLOBAL = 503;
+    const T_AS = 504;
+    const T_ENUM = 506;
+    const T_CONTINUE = 508;
+    const T_SWITCH = 509;
+    const T_BREAK = 510;
+    const T_AND = 511;
+    const T_OR = 512;
+    const T_XOR = 513;
+    const T_EXTENSION = 800;
+    const T_PRINT = 801;
+    const T_TRY = 515;
+    const T_RESCUE = 516;
+    const T_FINALLY = 517;
+    const T_RAISE = 518;
+    const T_ELIF = 520;
+    const T_ELSE = 521;
+    const T_CASE = 522;
+    const T_SUPER = 525;
+    const T_IS = 527;
+    const T_DERIVING = 529;
+    const T_MOD = 292;
+    const T_NOT = 293;
+    const T_FN = 294;
+    const T_INCLUDE = 295;
+    const T_REQUIRE = 296;
+    const T_ONCE = 297;
+    const T_THEN = 300;
+    const T_BEGIN = 301;
+    const T_END = 302;
+    const T_FROM = 303;
+    const T_TO = 304;
+    const T_BY = 305;
+    const T_WHEN = 306;
+    const T_UNLESS = 307;
 
-  /* Operators */
+    /* Operators */
 
-  # <
-  const T_LESSER              = 1000; # <
-  const T_RETURN              = 1001; # <<<
-  const T_BITWISE_SHIFT_LEFT  = 1002; # <<
-  const T_DIFFERENT           = 1003; # <>
-  const T_LESSER_OR_EQUAL     = 1004; # <=
+    # <
+    const T_LESSER              = 1000; # <
+    const T_RETURN              = 1001; # <<<
+    const T_BITWISE_SHIFT_LEFT  = 1002; # <<
+    const T_DIFFERENT           = 1003; # <>
+    const T_LESSER_OR_EQUAL     = 1004; # <=
 
-  # >
-  const T_GREATER             = 1005; # >
-  const T_ECHO                = 1006; # >>>
-  const T_GREATER_OR_EQUAL    = 1007; # >=
-  const T_BITWISE_SHIFT_RIGHT = 1008; # >>>
+    # >
+    const T_GREATER             = 1005; # >
+    const T_ECHO                = 1006; # >>>
+    const T_GREATER_OR_EQUAL    = 1007; # >=
+    const T_BITWISE_SHIFT_RIGHT = 1008; # >>>
 
-  # :
-  const T_COLON               = 1009; # :
-  const T_ASSIGN              = 1010; # :-
+    # :
+    const T_COLON               = 1009; # :
+    const T_ASSIGN              = 1010; # :-
 
-  # -
-  const T_PLUS                = 1011; # +
-  const T_CONCAT_LIST         = 1012; # +++
-  const T_CONCAT              = 1013; # ++
+    # -
+    const T_PLUS                = 1011; # +
+    const T_CONCAT_LIST         = 1012; # +++
+    const T_CONCAT              = 1013; # ++
 
-  # *
-  const T_STAR                = 1014; # *
-  const T_POW                 = 1015; # **
+    # *
+    const T_STAR                = 1014; # *
+    const T_POW                 = 1015; # **
 
-  # =
-  const T_EQUAL               = 1016; # =
-  const T_REGEX_EQUAL         = 1017; # =~
+    # =
+    const T_EQUAL               = 1016; # =
+    const T_REGEX_EQUAL         = 1017; # =~
 
-  # |
-  const T_BITWISE_OR          = 1018; # |
-  const T_PIPELINE            = 1019; # |>
+    # |
+    const T_BITWISE_OR          = 1018; # |
+    const T_PIPELINE            = 1019; # |>
 
-  # ^
-  const T_CIRCUNFLEX          = 1020; # ^
-  const T_CLONE               = 1021; # ^^
+    # ^
+    const T_CIRCUNFLEX          = 1020; # ^
+    const T_CLONE               = 1021; # ^^
 
-  # &
-  const T_BITWISE_AND         = 1022; # &
-  const T_PARAMETERLESS_FN    = 1023; # &{ expr }
-  const T_PARTIAL_FN          = 1024; # &( op expr )
+    # &
+    const T_BITWISE_AND         = 1022; # &
+    const T_PARAMETERLESS_FN    = 1023; # &{ expr }
+    const T_PARTIAL_FN          = 1024; # &( op expr )
 
-  # .
-  const T_DOT                 = 1025; # .
-  const T_ELLIPSIS            = 1026; # ...
+    # .
+    const T_DOT                 = 1025; # .
+    const T_ELLIPSIS            = 1026; # ...
 
-  # ?
-  const T_SIMPLE_IF           = 1027; # ?
-  const T_SIMPLE_TERNARY      = 1028; # ?:
-  const T_NULL_COALESCENCE    = 1029; # ??
+    # ?
+    const T_SIMPLE_IF           = 1027; # ?
+    const T_SIMPLE_TERNARY      = 1028; # ?:
+    const T_NULL_COALESCENCE    = 1029; # ??
 
-  # Single char operators
-  const T_NEW                 = 1030; # #
-  const T_AT                  = 1031; # @
-  const T_BANG                = 1032; # !
-  const T_MINUS               = 1033; # -
-  const T_BITWISE_NOT         = 1034; # ~
+    # Single char operators
+    const T_NEW                 = 1030; # #
+    const T_AT                  = 1031; # @
+    const T_BANG                = 1032; # !
+    const T_MINUS               = 1033; # -
+    const T_BITWISE_NOT         = 1034; # ~
 
-  static function getPunctuator($code)
-  {
-    $op_table = static::getOpTable();
+    public static function getPunctuator($code)
+    {
+        $op_table = static::getOpTable();
 
-    if (in_array($code, $op_table, true)) {
-      if (is_string($code)) {
-        return $code;
-      }
+        if (in_array($code, $op_table, true)) {
+            if (is_string($code)) {
+                return $code;
+            }
 
-      switch ($code) {
-        case Tag::T_AND:
-          return 'and';
-        case Tag::T_OR:
-          return 'or';
-        case Tag::T_XOR:
-          return 'xor';
-        case Tag::T_NOT:
-          return 'not';
-        case Tag::T_MOD:
-          return 'mod';
-      }
+            switch ($code) {
+                case Tag::T_AND:
+                    return 'and';
+                case Tag::T_OR:
+                    return 'or';
+                case Tag::T_XOR:
+                    return 'xor';
+                case Tag::T_NOT:
+                    return 'not';
+                case Tag::T_MOD:
+                    return 'mod';
+            }
+        }
+
+        return null;
     }
 
-    return NULL;
-  }
+    // TODO: Separate operators that can be used as the start of an expression
+    // from the others
+    public static function getOpTable()
+    {
+        return [
+            Tag::T_LESSER              => '<',
+            Tag::T_RETURN              => '^',
+            Tag::T_BITWISE_SHIFT_LEFT  => '<<',
+            Tag::T_DIFFERENT           => '<>',
+            Tag::T_LESSER_OR_EQUAL     => '<=',
+            Tag::T_GREATER             => '>',
+            Tag::T_ECHO                => '>>>',
+            Tag::T_GREATER_OR_EQUAL    => '>=',
+            Tag::T_BITWISE_SHIFT_RIGHT => '>>',
+            Tag::T_COLON               => ':',
+            Tag::T_ASSIGN              => ':-',
+            Tag::T_PLUS                => '+',
+            Tag::T_CONCAT_LIST         => '+++',
+            Tag::T_CONCAT              => '++',
+            Tag::T_STAR                => '*',
+            Tag::T_POW                 => '**',
+            Tag::T_EQUAL               => '=',
+            Tag::T_REGEX_EQUAL         => '=~',
+            Tag::T_BITWISE_OR          => '|',
+            Tag::T_PIPELINE            => '|>',
+            Tag::T_CIRCUNFLEX          => '^',
+            Tag::T_CLONE               => '^^',
+            Tag::T_BITWISE_AND         => '&',
+            Tag::T_PARAMETERLESS_FN    => '&{',
+            Tag::T_PARTIAL_FN          => '&(',
+            Tag::T_DOT                 => '.',
+            Tag::T_ELLIPSIS            => '...',
+            Tag::T_SIMPLE_IF           => '?',
+            Tag::T_SIMPLE_TERNARY      => '?:',
+            Tag::T_NULL_COALESCENCE    => '??',
+            Tag::T_NEW                 => 'new',
+            Tag::T_AT                  => '@',
+            Tag::T_BANG                => '!',
+            Tag::T_MINUS               => '-',
+            Tag::T_BITWISE_NOT         => '~',
+            Tag::T_NEW                 => '#',
+            Tag::T_AND                 => Tag::T_AND,
+            Tag::T_OR                  => Tag::T_OR,
+            Tag::T_XOR                 => Tag::T_XOR,
+            Tag::T_NOT                 => Tag::T_NOT,
+            Tag::T_MOD                 => Tag::T_MOD
+        ];
+    }
 
-  // TODO: Separate operators that can be used as the start of an expression
-  // from the others
-  static function getOpTable() {
-    return [
-      Tag::T_LESSER              => '<',
-      Tag::T_RETURN              => '^',
-      Tag::T_BITWISE_SHIFT_LEFT  => '<<',
-      Tag::T_DIFFERENT           => '<>',
-      Tag::T_LESSER_OR_EQUAL     => '<=',
-      Tag::T_GREATER             => '>',
-      Tag::T_ECHO                => '>>>',
-      Tag::T_GREATER_OR_EQUAL    => '>=',
-      Tag::T_BITWISE_SHIFT_RIGHT => '>>',
-      Tag::T_COLON               => ':',
-      Tag::T_ASSIGN              => ':-',
-      Tag::T_PLUS                => '+',
-      Tag::T_CONCAT_LIST         => '+++',
-      Tag::T_CONCAT              => '++',
-      Tag::T_STAR                => '*',
-      Tag::T_POW                 => '**',
-      Tag::T_EQUAL               => '=',
-      Tag::T_REGEX_EQUAL         => '=~',
-      Tag::T_BITWISE_OR          => '|',
-      Tag::T_PIPELINE            => '|>',
-      Tag::T_CIRCUNFLEX          => '^',
-      Tag::T_CLONE               => '^^',
-      Tag::T_BITWISE_AND         => '&',
-      Tag::T_PARAMETERLESS_FN    => '&{',
-      Tag::T_PARTIAL_FN          => '&(',
-      Tag::T_DOT                 => '.',
-      Tag::T_ELLIPSIS            => '...',
-      Tag::T_SIMPLE_IF           => '?',
-      Tag::T_SIMPLE_TERNARY      => '?:',
-      Tag::T_NULL_COALESCENCE    => '??',
-      Tag::T_NEW                 => 'new',
-      Tag::T_AT                  => '@',
-      Tag::T_BANG                => '!',
-      Tag::T_MINUS               => '-',
-      Tag::T_BITWISE_NOT         => '~',
-      Tag::T_NEW                 => '#',
-      Tag::T_AND                 => Tag::T_AND,
-      Tag::T_OR                  => Tag::T_OR,
-      Tag::T_XOR                 => Tag::T_XOR,
-      Tag::T_NOT                 => Tag::T_NOT,
-      Tag::T_MOD                 => Tag::T_MOD
-    ];
-  }
-
-  static function getName($x)
-  {
-    return array_search($x, (new ReflectionClass(__CLASS__))->getConstants());
-  }
+    public static function getName($x)
+    {
+        return array_search($x, (new ReflectionClass(__CLASS__))->getConstants());
+    }
 }

--- a/src/lexer/Tag.php
+++ b/src/lexer/Tag.php
@@ -64,7 +64,6 @@ class Tag
     const T_OR = 512;
     const T_XOR = 513;
     const T_EXTENSION = 800;
-    const T_PRINT = 801;
     const T_TRY = 515;
     const T_RESCUE = 516;
     const T_FINALLY = 517;

--- a/src/lexer/Token.php
+++ b/src/lexer/Token.php
@@ -23,39 +23,39 @@ namespace QuackCompiler\Lexer;
 
 class Token
 {
-  private $tag;
-  private $pointer;
-  private $symbol_table;
+    private $tag;
+    private $pointer;
+    private $symbol_table;
 
-  public function __construct($tag, $pointer = NULL)
-  {
-    $this->tag = $tag;
-    $this->pointer = $pointer;
-  }
-
-  public function getTag()
-  {
-    return $this->tag;
-  }
-
-  public function getPointer()
-  {
-    return $this->pointer;
-  }
-
-  public function __toString()
-  {
-    if (isset($this->pointer)) {
-      $tag_name = Tag::getName($this->tag);
-      return isset($this->symbol_table)
-        ? "[" . $tag_name . ", " . $this->symbol_table->get($this->pointer) . "]"
-        : "[" . $tag_name . ", " . $this->pointer . "]";
+    public function __construct($tag, $pointer = null)
+    {
+        $this->tag = $tag;
+        $this->pointer = $pointer;
     }
-    return "[" . $this->tag . "]";
-  }
 
-  public function showSymbolTable(SymbolTable &$symbol_table)
-  {
-    $this->symbol_table = $symbol_table;
-  }
+    public function getTag()
+    {
+        return $this->tag;
+    }
+
+    public function getPointer()
+    {
+        return $this->pointer;
+    }
+
+    public function __toString()
+    {
+        if (isset($this->pointer)) {
+            $tag_name = Tag::getName($this->tag);
+            return isset($this->symbol_table)
+                ? "[" . $tag_name . ", " . $this->symbol_table->get($this->pointer) . "]"
+                : "[" . $tag_name . ", " . $this->pointer . "]";
+        }
+        return "[" . $this->tag . "]";
+    }
+
+    public function showSymbolTable(SymbolTable &$symbol_table)
+    {
+        $this->symbol_table = $symbol_table;
+    }
 }

--- a/src/lexer/Word.php
+++ b/src/lexer/Word.php
@@ -23,16 +23,16 @@ namespace QuackCompiler\Lexer;
 
 class Word extends Token
 {
-  public $lexeme;
+    public $lexeme;
 
-  public function __construct($tag, $word)
-  {
-    parent::__construct($tag);
-    $this->lexeme = (string) $word;
-  }
+    public function __construct($tag, $word)
+    {
+        parent::__construct($tag);
+        $this->lexeme = (string) $word;
+    }
 
-  public function __toString()
-  {
-    return "[" . $this->lexeme . "]";
-  }
+    public function __toString()
+    {
+        return "[" . $this->lexeme . "]";
+    }
 }

--- a/src/parselets/AccessParselet.php
+++ b/src/parselets/AccessParselet.php
@@ -29,16 +29,16 @@ use \QuackCompiler\Parser\Precedence;
 
 class AccessParselet implements IInfixParselet
 {
-  public function parse(Grammar $grammar, Expr $left, Token $token)
-  {
-    $index = $grammar->_expr();
-    $grammar->parser->match('}');
+    public function parse(Grammar $grammar, Expr $left, Token $token)
+    {
+        $index = $grammar->_expr();
+        $grammar->parser->match('}');
 
-    return new AccessExpr($left, $index);
-  }
+        return new AccessExpr($left, $index);
+    }
 
-  public function getPrecedence()
-  {
-    return Precedence::ACCESS;
-  }
+    public function getPrecedence()
+    {
+        return Precedence::ACCESS;
+    }
 }

--- a/src/parselets/ArrayParselet.php
+++ b/src/parselets/ArrayParselet.php
@@ -27,10 +27,10 @@ use \QuackCompiler\Lexer\Token;
 
 class ArrayParselet implements IPrefixParselet
 {
-  public function parse(Grammar $grammar, Token $token)
-  {
-    $items = iterator_to_array($grammar->_arrayPairList());
-    $grammar->parser->match('}');
-    return new ArrayExpr($items);
-  }
+    public function parse(Grammar $grammar, Token $token)
+    {
+        $items = iterator_to_array($grammar->_arrayPairList());
+        $grammar->parser->match('}');
+        return new ArrayExpr($items);
+    }
 }

--- a/src/parselets/BinaryOperatorParselet.php
+++ b/src/parselets/BinaryOperatorParselet.php
@@ -28,23 +28,23 @@ use \QuackCompiler\Lexer\Token;
 
 class BinaryOperatorParselet implements IInfixParselet
 {
-  public $precedence;
-  public $is_right;
+    public $precedence;
+    public $is_right;
 
-  public function __construct($precedence, $is_right)
-  {
-    $this->precedence = $precedence;
-    $this->is_right = $is_right;
-  }
+    public function __construct($precedence, $is_right)
+    {
+        $this->precedence = $precedence;
+        $this->is_right = $is_right;
+    }
 
-  public function parse(Grammar $parser, Expr $left, Token $token)
-  {
-    $right = $parser->_expr($this->precedence - ($this->is_right ? 1 : 0));
-    return new OperatorExpr($left, $token->getTag(), $right);
-  }
+    public function parse(Grammar $parser, Expr $left, Token $token)
+    {
+        $right = $parser->_expr($this->precedence - ($this->is_right ? 1 : 0));
+        return new OperatorExpr($left, $token->getTag(), $right);
+    }
 
-  public function getPrecedence()
-  {
-    return $this->precedence;
-  }
+    public function getPrecedence()
+    {
+        return $this->precedence;
+    }
 }

--- a/src/parselets/CallParselet.php
+++ b/src/parselets/CallParselet.php
@@ -29,26 +29,26 @@ use \QuackCompiler\Parser\Precedence;
 
 class CallParselet implements IInfixParselet
 {
-  public function parse(Grammar $grammar, Expr $left, Token $token)
-  {
-    $args = [];
+    public function parse(Grammar $grammar, Expr $left, Token $token)
+    {
+        $args = [];
 
-    if (!$grammar->parser->is(']')) {
-      $args[] = $grammar->_expr();
+        if (!$grammar->parser->is(']')) {
+            $args[] = $grammar->_expr();
 
-      while ($grammar->parser->is(';')) {
-        $grammar->parser->consume();
-        $args[] = $grammar->_expr();
-      }
+            while ($grammar->parser->is(';')) {
+                $grammar->parser->consume();
+                $args[] = $grammar->_expr();
+            }
+        }
+
+        $grammar->parser->match(']');
+
+        return new CallExpr($left, $args);
     }
 
-    $grammar->parser->match(']');
-
-    return new CallExpr($left, $args);
-  }
-
-  public function getPrecedence()
-  {
-    return Precedence::CALL;
-  }
+    public function getPrecedence()
+    {
+        return Precedence::CALL;
+    }
 }

--- a/src/parselets/FunctionParselet.php
+++ b/src/parselets/FunctionParselet.php
@@ -29,70 +29,69 @@ use \QuackCompiler\Lexer\Token;
 
 class FunctionParselet implements IPrefixParselet
 {
-  const TYPE_EXPRESSION = 0x1;
-  const TYPE_STATEMENT  = 0x2;
+    const TYPE_EXPRESSION = 0x1;
+    const TYPE_STATEMENT  = 0x2;
 
-  private $is_static;
+    private $is_static;
 
-  public function __construct($is_static = false)
-  {
-    $this->is_static = $is_static;
-  }
-
-  public function parse(Grammar $grammar, Token $token)
-  {
-    $this->is_static && $grammar->parser->consume(); // Eat [fn] when static function
-    // TODO: implement use
-    ($by_reference = $grammar->parser->is('*')) && $grammar->parser->consume();
-
-    $parameters = [];
-    $type = NULL;
-    $value = NULL;
-    $lexical_vars = [];
-
-    $grammar->parser->match('{');
-
-    while ($grammar->checker->startsParameter()) {
-      $parameters[] = $grammar->_parameter();
-
-      if ($grammar->parser->is(';')) {
-        $grammar->parser->consume();
-      } else {
-        break;
-      }
+    public function __construct($is_static = false)
+    {
+        $this->is_static = $is_static;
     }
 
-    $grammar->parser->match('|');
-    if ($grammar->parser->is('[')) {
-      $type = static::TYPE_STATEMENT;
-      $grammar->parser->match('[');
-      $value = iterator_to_array($grammar->_innerStmtList());
-      $grammar->parser->match(']');
-    } else {
-      $type = static::TYPE_EXPRESSION;
-      $value = $grammar->_expr();
-    }
+    public function parse(Grammar $grammar, Token $token)
+    {
+        $this->is_static && $grammar->parser->consume(); // Eat [fn] when static function
+        // TODO: implement use
+        ($by_reference = $grammar->parser->is('*')) && $grammar->parser->consume();
 
-    $grammar->parser->match('}');
+        $parameters = [];
+        $type = null;
+        $value = null;
+        $lexical_vars = [];
 
-    if ($grammar->parser->is(Tag::T_DERIVING)) {
-      $grammar->parser->consume();
+        $grammar->parser->match('{');
 
-      if ($grammar->parser->is('{')) {
-        do {
-          $grammar->parser->consume();
-          ($deriving_by_reference = $grammar->parser->is('*')) && $grammar->parser->consume();
-          $lexical_vars[] = ($deriving_by_reference ? '*' : '') . $grammar->identifier();
-        } while ($grammar->parser->is(';'));
+        while ($grammar->checker->startsParameter()) {
+            $parameters[] = $grammar->_parameter();
+
+            if ($grammar->parser->is(';')) {
+                $grammar->parser->consume();
+            } else {
+                break;
+            }
+        }
+
+        $grammar->parser->match('|');
+        if ($grammar->parser->is('[')) {
+            $type = static::TYPE_STATEMENT;
+            $grammar->parser->match('[');
+            $value = iterator_to_array($grammar->_innerStmtList());
+            $grammar->parser->match(']');
+        } else {
+            $type = static::TYPE_EXPRESSION;
+            $value = $grammar->_expr();
+        }
+
         $grammar->parser->match('}');
-      } else {
-        ($deriving_by_reference = $grammar->parser->is('*')) && $grammar->parser->consume();
-        $lexical_vars[] = ($deriving_by_reference ? '*' : '') . $grammar->identifier();
-      }
+
+        if ($grammar->parser->is(Tag::T_DERIVING)) {
+            $grammar->parser->consume();
+
+            if ($grammar->parser->is('{')) {
+                do {
+                    $grammar->parser->consume();
+                    ($deriving_by_reference = $grammar->parser->is('*')) && $grammar->parser->consume();
+                    $lexical_vars[] = ($deriving_by_reference ? '*' : '') . $grammar->identifier();
+                } while ($grammar->parser->is(';'));
+
+                $grammar->parser->match('}');
+            } else {
+                ($deriving_by_reference = $grammar->parser->is('*')) && $grammar->parser->consume();
+                $lexical_vars[] = ($deriving_by_reference ? '*' : '') . $grammar->identifier();
+            }
+        }
+
+        return new LambdaExpr($by_reference, $parameters, $type, $value, $this->is_static, $lexical_vars);
     }
-
-    return new LambdaExpr($by_reference, $parameters, $type, $value, $this->is_static, $lexical_vars);
-  }
 }
-
-

--- a/src/parselets/GroupParselet.php
+++ b/src/parselets/GroupParselet.php
@@ -28,10 +28,10 @@ use \QuackCompiler\Lexer\Token;
 
 class GroupParselet implements IPrefixParselet
 {
-  public function parse(Grammar $grammar, Token $token)
-  {
-    $expr = $grammar->_expr();
-    $grammar->parser->match(')');
-    return $expr;
-  }
+    public function parse(Grammar $grammar, Token $token)
+    {
+        $expr = $grammar->_expr();
+        $grammar->parser->match(')');
+        return $expr;
+    }
 }

--- a/src/parselets/IInfixParselet.php
+++ b/src/parselets/IInfixParselet.php
@@ -27,6 +27,6 @@ use \QuackCompiler\Parser\Grammar;
 
 interface IInfixParselet
 {
-  function parse(Grammar $parser, Expr $left, Token $token);
-  function getPrecedence();
+    public function parse(Grammar $parser, Expr $left, Token $token);
+    public function getPrecedence();
 }

--- a/src/parselets/IPrefixParselet.php
+++ b/src/parselets/IPrefixParselet.php
@@ -26,5 +26,5 @@ use \QuackCompiler\Parser\Grammar;
 
 interface IPrefixParselet
 {
-  function parse(Grammar $parser, Token $token);
+    public function parse(Grammar $parser, Token $token);
 }

--- a/src/parselets/IncludeParselet.php
+++ b/src/parselets/IncludeParselet.php
@@ -28,17 +28,17 @@ use \QuackCompiler\Parser\Grammar;
 
 class IncludeParselet implements IPrefixParselet
 {
-  const TYPE_REQUIRE = 0x1;
-  const TYPE_INCLUDE = 0x2;
+    const TYPE_REQUIRE = 0x1;
+    const TYPE_INCLUDE = 0x2;
 
-  public function parse(Grammar $grammar, Token $token)
-  {
-    $type = $token->getTag() === Tag::T_REQUIRE
-      ? static::TYPE_REQUIRE
-      : static::TYPE_INCLUDE;
-    $is_once = $grammar->parser->is(Tag::T_ONCE) && $grammar->parser->consume();
-    $file = $grammar->_expr();
+    public function parse(Grammar $grammar, Token $token)
+    {
+        $type = $token->getTag() === Tag::T_REQUIRE
+            ? static::TYPE_REQUIRE
+            : static::TYPE_INCLUDE;
+        $is_once = $grammar->parser->is(Tag::T_ONCE) && $grammar->parser->consume();
+        $file = $grammar->_expr();
 
-    return new IncludeExpr($type, $is_once, $file);
-  }
+        return new IncludeExpr($type, $is_once, $file);
+    }
 }

--- a/src/parselets/LiteralParselet.php
+++ b/src/parselets/LiteralParselet.php
@@ -32,28 +32,30 @@ use \QuackCompiler\Parser\Grammar;
 
 class LiteralParselet implements IPrefixParselet
 {
-  public function parse(Grammar $grammar, Token $token)
-  {
-    $tag = $token->getTag();
+    public function parse(Grammar $grammar, Token $token)
+    {
+        $tag = $token->getTag();
 
-    switch ($tag) {
-      case Tag::T_ATOM:
-        return new AtomExpr($grammar->parser->resolveScope($token->getPointer()));
+        switch ($tag) {
+            case Tag::T_ATOM:
+                return new AtomExpr($grammar->parser->resolveScope($token->getPointer()));
 
-      case Tag::T_STRING:
-        return new StringExpr($grammar->parser->resolveScope($token->getPointer()));
+            case Tag::T_STRING:
+                return new StringExpr($grammar->parser->resolveScope($token->getPointer()));
 
-      case Tag::T_DOUBLE:
-      case Tag::T_INTEGER:
-        return new NumberExpr($grammar->parser->resolveScope($token->getPointer()),
-          $tag === Tag::T_DOUBLE ? 'double' : 'int');
+            case Tag::T_DOUBLE:
+            case Tag::T_INTEGER:
+                return new NumberExpr(
+                    $grammar->parser->resolveScope($token->getPointer()),
+                    $tag === Tag::T_DOUBLE ? 'double' : 'int'
+                );
 
-      case Tag::T_NIL:
-        return new NilExpr;
+            case Tag::T_NIL:
+                return new NilExpr;
 
-      case Tag::T_TRUE:
-      case Tag::T_FALSE:
-        return new BoolExpr($tag === Tag::T_TRUE);
+            case Tag::T_TRUE:
+            case Tag::T_FALSE:
+                return new BoolExpr($tag === Tag::T_TRUE);
+        }
     }
-  }
 }

--- a/src/parselets/MemberAccessParselet.php
+++ b/src/parselets/MemberAccessParselet.php
@@ -33,15 +33,18 @@ use \QuackCompiler\Lexer\Tag;
 
 class MemberAccessParselet implements IInfixParselet
 {
-  public function parse(Grammar $grammar, Expr $left, Token $token)
-  {
-    $right = $grammar->_name();
-    return new OperatorExpr($left, $token->getTag(),
-      new NameExpr($grammar->parser->resolveScope($right->getPointer())));
-  }
+    public function parse(Grammar $grammar, Expr $left, Token $token)
+    {
+        $right = $grammar->_name();
+        return new OperatorExpr(
+            $left,
+            $token->getTag(),
+            new NameExpr($grammar->parser->resolveScope($right->getPointer()))
+        );
+    }
 
-  public function getPrecedence()
-  {
-    return Precedence::MEMBER_ACCESS;
-  }
+    public function getPrecedence()
+    {
+        return Precedence::MEMBER_ACCESS;
+    }
 }

--- a/src/parselets/NameParselet.php
+++ b/src/parselets/NameParselet.php
@@ -27,8 +27,8 @@ use \QuackCompiler\Parser\Grammar;
 
 class NameParselet implements IPrefixParselet
 {
-  public function parse(Grammar $grammar, Token $token)
-  {
-    return new NameExpr($grammar->parser->resolveScope($token->getPointer()));
-  }
+    public function parse(Grammar $grammar, Token $token)
+    {
+        return new NameExpr($grammar->parser->resolveScope($token->getPointer()));
+    }
 }

--- a/src/parselets/NewParselet.php
+++ b/src/parselets/NewParselet.php
@@ -28,27 +28,27 @@ use \QuackCompiler\Lexer\Token;
 
 class NewParselet implements IPrefixParselet
 {
-  public function parse(Grammar $grammar, Token $token)
-  {
-    $class_name = $grammar->qualifiedName();
-    $ctor_args = [];
+    public function parse(Grammar $grammar, Token $token)
+    {
+        $class_name = $grammar->qualifiedName();
+        $ctor_args = [];
 
-    if ($grammar->parser->is('[')) {
-      $grammar->parser->consume();
+        if ($grammar->parser->is('[')) {
+            $grammar->parser->consume();
 
-      while ($grammar->checker->startsExpr()) {
-        $ctor_args[] = $grammar->_expr();
+            while ($grammar->checker->startsExpr()) {
+                $ctor_args[] = $grammar->_expr();
 
-        if (!$grammar->parser->is(']')) {
-          $grammar->parser->match(';');
+                if (!$grammar->parser->is(']')) {
+                    $grammar->parser->match(';');
+                }
+            }
+
+            $grammar->parser->match(']');
+        } else {
+            $grammar->parser->match('!');
         }
-      }
 
-      $grammar->parser->match(']');
-    } else {
-      $grammar->parser->match('!');
+        return new NewExpr($class_name, $ctor_args);
     }
-
-    return new NewExpr($class_name, $ctor_args);
-  }
 }

--- a/src/parselets/PostfixOperatorParselet.php
+++ b/src/parselets/PostfixOperatorParselet.php
@@ -28,20 +28,20 @@ use \QuackCompiler\Lexer\Token;
 
 class PostfixOperatorParselet implements IInfixParselet
 {
-  public $precedence;
+    public $precedence;
 
-  public function __construct($precedence)
-  {
-    $this->precedence = $precedence;
-  }
+    public function __construct($precedence)
+    {
+        $this->precedence = $precedence;
+    }
 
-  public function parse(Grammar $parser, Expr $left, Token $token)
-  {
-    return new PostfixExpr($left, $token->getTag());
-  }
+    public function parse(Grammar $parser, Expr $left, Token $token)
+    {
+        return new PostfixExpr($left, $token->getTag());
+    }
 
-  public function getPrecedence()
-  {
-    return $this->precedence;
-  }
+    public function getPrecedence()
+    {
+        return $this->precedence;
+    }
 }

--- a/src/parselets/PrefixOperatorParselet.php
+++ b/src/parselets/PrefixOperatorParselet.php
@@ -27,21 +27,21 @@ use \QuackCompiler\Parser\Grammar;
 
 class PrefixOperatorParselet implements IPrefixParselet
 {
-  public $precedence;
+    public $precedence;
 
-  public function __construct($precedence)
-  {
-    $this->precedence = $precedence;
-  }
+    public function __construct($precedence)
+    {
+        $this->precedence = $precedence;
+    }
 
-  public function parse(Grammar $parser, Token $token)
-  {
-    $operand = $parser->_expr($this->precedence);
-    return new PrefixExpr($token, $operand);
-  }
+    public function parse(Grammar $parser, Token $token)
+    {
+        $operand = $parser->_expr($this->precedence);
+        return new PrefixExpr($token, $operand);
+    }
 
-  public function getPrecedence()
-  {
-    return $this->precedence;
-  }
+    public function getPrecedence()
+    {
+        return $this->precedence;
+    }
 }

--- a/src/parselets/RangeParselet.php
+++ b/src/parselets/RangeParselet.php
@@ -30,21 +30,21 @@ use \QuackCompiler\Lexer\Tag;
 
 class RangeParselet implements IInfixParselet
 {
-  public function parse(Grammar $grammar, Expr $from, Token $token)
-  {
-    $to = $grammar->_expr();
-    $by = NULL;
+    public function parse(Grammar $grammar, Expr $from, Token $token)
+    {
+        $to = $grammar->_expr();
+        $by = null;
 
-    if ($grammar->parser->is(Tag::T_BY)) {
-      $grammar->parser->consume();
-      $by = $grammar->_expr();
+        if ($grammar->parser->is(Tag::T_BY)) {
+            $grammar->parser->consume();
+            $by = $grammar->_expr();
+        }
+
+        return new RangeExpr($from, $to, $by);
     }
 
-    return new RangeExpr($from, $to, $by);
-  }
-
-  public function getPrecedence()
-  {
-    return Precedence::RANGE;
-  }
+    public function getPrecedence()
+    {
+        return Precedence::RANGE;
+    }
 }

--- a/src/parselets/TernaryParselet.php
+++ b/src/parselets/TernaryParselet.php
@@ -30,16 +30,16 @@ use \QuackCompiler\Lexer\Tag;
 
 class TernaryParselet implements IInfixParselet
 {
-  public function parse(Grammar $grammar, Expr $left, Token $token)
-  {
-    $then = $grammar->_expr();
-    $grammar->parser->match(Tag::T_ELSE);
-    $else = $grammar->_expr(Precedence::TERNARY - 1);
-    return new TernaryExpr($left, $then, $else);
-  }
+    public function parse(Grammar $grammar, Expr $left, Token $token)
+    {
+        $then = $grammar->_expr();
+        $grammar->parser->match(Tag::T_ELSE);
+        $else = $grammar->_expr(Precedence::TERNARY - 1);
+        return new TernaryExpr($left, $then, $else);
+    }
 
-  public function getPrecedence()
-  {
-    return Precedence::TERNARY;
-  }
+    public function getPrecedence()
+    {
+        return Precedence::TERNARY;
+    }
 }

--- a/src/parselets/WhenParselet.php
+++ b/src/parselets/WhenParselet.php
@@ -29,38 +29,37 @@ use \QuackCompiler\Lexer\Tag;
 
 class WhenParselet implements IPrefixParselet
 {
-  public function parse(Grammar $grammar, Token $token)
-  {
-    $cases = [];
+    public function parse(Grammar $grammar, Token $token)
+    {
+        $cases = [];
 
-    do {
-      $grammar->parser->consume();
+        do {
+            $grammar->parser->consume();
 
-      // Default operation
-      if ($grammar->parser->is(Tag::T_ELSE)) {
-        $grammar->parser->consume();
-        $default = new \stdClass;
-        $default->condition = NULL;
-        $default->action = $grammar->_expr();
-        $cases[] = $default;
-        goto fetch_next;
-      }
+            // Default operation
+            if ($grammar->parser->is(Tag::T_ELSE)) {
+                $grammar->parser->consume();
+                $default = new \stdClass;
+                $default->condition = null;
+                $default->action = $grammar->_expr();
+                $cases[] = $default;
+                goto fetch_next;
+            }
 
-      $case = new \stdClass;
-      $case->condition = $grammar->_expr();
-      $grammar->parser->match('->');
-      $case->action = $grammar->_expr();
-      $cases[] = $case;
+            $case = new \stdClass;
+            $case->condition = $grammar->_expr();
+            $grammar->parser->match('->');
+            $case->action = $grammar->_expr();
+            $cases[] = $case;
 
-      fetch_next:
-      if (!$grammar->parser->is(Tag::T_END)) {
-        $grammar->parser->match(';');
-      }
+            fetch_next:
+            if (!$grammar->parser->is(Tag::T_END)) {
+                $grammar->parser->match(';');
+            }
+        } while ($grammar->parser->is('|'));
 
-    } while ($grammar->parser->is('|'));
+        $grammar->parser->match(Tag::T_END);
 
-    $grammar->parser->match(Tag::T_END);
-
-    return new WhenExpr($cases);
-  }
+        return new WhenExpr($cases);
+    }
 }

--- a/src/parser/Grammar.php
+++ b/src/parser/Grammar.php
@@ -143,7 +143,6 @@ class Grammar
             Tag::T_GOTO     => '_gotoStmt',
             Tag::T_GLOBAL   => '_globalStmt',
             Tag::T_RAISE    => '_raiseStmt',
-            Tag::T_PRINT    => '_printStmt',
             Tag::T_BEGIN    => '_blockStmt',
             '^'             => '_returnStmt',
             ':-'            => '_labelStmt'
@@ -325,14 +324,6 @@ class Grammar
         $expression = $this->_expr();
 
         return new RaiseStmt($expression);
-    }
-
-    public function _printStmt()
-    {
-        $this->parser->match(Tag::T_PRINT);
-        $expression = $this->_expr();
-
-        return new PrintStmt($expression);
     }
 
     public function _returnStmt()

--- a/src/parser/Parser.php
+++ b/src/parser/Parser.php
@@ -46,202 +46,202 @@ use \QuackCompiler\Parselets\RangeParselet;
 
 abstract class Parser
 {
-  public $input;
-  public $lookahead;
-  public $scope_level = 0;
+    public $input;
+    public $lookahead;
+    public $scope_level = 0;
 
-  public $prefix_parselets = [];
-  public $infix_parselets = [];
+    public $prefix_parselets = [];
+    public $infix_parselets = [];
 
-  public function __construct(Tokenizer $input)
-  {
-    $this->registerParselets();
-    $this->input = $input;
-    $this->consume();
-  }
-
-  private function register($tag, $parselet)
-  {
-    if ($parselet instanceof IPrefixParselet) {
-      $this->prefix_parselets[$tag] = $parselet;
-    } else if ($parselet instanceof IInfixParselet) {
-      $this->infix_parselets[$tag] = $parselet;
-    }
-  }
-
-  private function postfix($tag, $precedence)
-  {
-    $this->register($tag, new PostfixOperatorParselet($precedence));
-  }
-
-  private function prefix($tag, $precedence)
-  {
-    $this->register($tag, new PrefixOperatorParselet($precedence));
-  }
-
-  private function infixLeft($tag, $precedence)
-  {
-    $this->register($tag, new BinaryOperatorParselet($precedence, false));
-  }
-
-  private function infixRight($tag, $precedence)
-  {
-    $this->register($tag, new BinaryOperatorParselet($precedence, true));
-  }
-
-  private function registerParselets()
-  {
-    $this->register(Tag::T_INTEGER, new LiteralParselet);
-    $this->register(Tag::T_DOUBLE, new LiteralParselet);
-    $this->register(Tag::T_STRING, new LiteralParselet);
-    $this->register(Tag::T_IDENT, new NameParselet);
-    $this->register(Tag::T_THEN, new TernaryParselet);
-    $this->register('..', new RangeParselet);
-    $this->register('(', new GroupParselet);
-    $this->register('[', new CallParselet);
-    $this->register('{', new ArrayParselet);
-    $this->register('{', new AccessParselet);
-    $this->register(Tag::T_FN, new FunctionParselet);
-    $this->register(Tag::T_REQUIRE, new IncludeParselet);
-    $this->register(Tag::T_INCLUDE, new IncludeParselet);
-    $this->register('#', new NewParselet);
-    $this->register('.', new MemberAccessParselet);
-    $this->register('?.', new MemberAccessParselet);
-    $this->register(Tag::T_TRUE, new LiteralParselet);
-    $this->register(Tag::T_FALSE, new LiteralParselet);
-    $this->register(Tag::T_NIL, new LiteralParselet);
-    $this->register(Tag::T_ATOM, new LiteralParselet);
-    $this->register(Tag::T_WHEN, new WhenParselet);
-
-    $this->prefix('+', Precedence::PREFIX);
-    $this->prefix('-', Precedence::PREFIX);
-    $this->prefix('^^', Precedence::PREFIX);
-    $this->prefix('*', Precedence::PREFIX);
-    $this->prefix('@', Precedence::PREFIX);
-    $this->prefix('~', Precedence::PREFIX);
-    $this->prefix(Tag::T_NOT, Precedence::PREFIX);
-
-    $this->postfix('!', Precedence::POSTFIX);
-
-    $this->infixLeft('+', Precedence::ADDITIVE);
-    $this->infixLeft('-', Precedence::ADDITIVE);
-    $this->infixLeft('++', Precedence::ADDITIVE);
-    $this->infixLeft('*', Precedence::MULTIPLICATIVE);
-    $this->infixLeft('/', Precedence::MULTIPLICATIVE);
-    $this->infixLeft(Tag::T_MOD, Precedence::MULTIPLICATIVE);
-    $this->infixLeft(Tag::T_AND, Precedence::LOGICAL_AND);
-    $this->infixLeft(Tag::T_OR, Precedence::LOGICAL_OR);
-    $this->infixLeft(Tag::T_XOR, Precedence::LOGICAL_XOR);
-    $this->infixLeft('|', Precedence::BITWISE_OR);
-    $this->infixLeft('&', Precedence::BITWISE_AND_OR_REF);
-    $this->infixLeft('^', Precedence::BITWISE_XOR);
-    $this->infixLeft('<<', Precedence::BITWISE_SHIFT);
-    $this->infixLeft('>>', Precedence::BITWISE_SHIFT);
-    $this->infixLeft('=', Precedence::VALUE_COMPARATOR);
-    $this->infixLeft('<>', Precedence::VALUE_COMPARATOR);
-    $this->infixLeft('<=', Precedence::SIZE_COMPARATOR);
-    $this->infixLeft('<', Precedence::SIZE_COMPARATOR);
-    $this->infixLeft('>=', Precedence::SIZE_COMPARATOR);
-    $this->infixLeft('>', Precedence::SIZE_COMPARATOR);
-    $this->infixLeft('|>', Precedence::PIPELINE);
-    $this->infixLeft('??', Precedence::COALESCENCE);
-    $this->infixLeft('?:', Precedence::TERNARY);
-
-    $this->infixRight('**', Precedence::EXPONENT);
-    $this->infixRight(':-', Precedence::ASSIGNMENT);
-  }
-
-  public function match($tag)
-  {
-    if ($this->lookahead->getTag() === $tag) {
-      return $this->consume();
+    public function __construct(Tokenizer $input)
+    {
+        $this->registerParselets();
+        $this->input = $input;
+        $this->consume();
     }
 
-    throw (new SyntaxError)
-      -> expected ($tag)
-      -> found    ($this->lookahead)
-      -> on       ($this->position())
-      -> source   ($this->input);
-  }
-
-  public function opt($tag)
-  {
-    if ($this->lookahead->getTag() === $tag) {
-      $pointer = $this->consume();
-      return $pointer === NULL ? true : $pointer;
+    private function register($tag, $parselet)
+    {
+        if ($parselet instanceof IPrefixParselet) {
+            $this->prefix_parselets[$tag] = $parselet;
+        } elseif ($parselet instanceof IInfixParselet) {
+            $this->infix_parselets[$tag] = $parselet;
+        }
     }
-    return false;
-  }
 
-  public function is($tag)
-  {
-    return $this->lookahead->getTag() === $tag;
-  }
+    private function postfix($tag, $precedence)
+    {
+        $this->register($tag, new PostfixOperatorParselet($precedence));
+    }
 
-  public function isOperator()
-  {
-    $op = $this->lookahead->getTag();
-    $op_table = array_values(Tag::getOpTable());
-    return in_array($op, $op_table, true);
-  }
+    private function prefix($tag, $precedence)
+    {
+        $this->register($tag, new PrefixOperatorParselet($precedence));
+    }
 
-  public function consume()
-  {
-    $pointer = $this->lookahead === NULL ?: $this->lookahead->getPointer();
-    $this->lookahead = $this->input->nextToken();
-    return $pointer;
-  }
+    private function infixLeft($tag, $precedence)
+    {
+        $this->register($tag, new BinaryOperatorParselet($precedence, false));
+    }
 
-  public function consumeAndFetch()
-  {
-    $clone = $this->lookahead;
-    $this->lookahead = $this->input->nextToken();
-    return $clone;
-  }
+    private function infixRight($tag, $precedence)
+    {
+        $this->register($tag, new BinaryOperatorParselet($precedence, true));
+    }
 
-  public function resolveScope($pointer)
-  {
-    return $this->input->getSymbolTable()->get($pointer);
-  }
+    private function registerParselets()
+    {
+        $this->register(Tag::T_INTEGER, new LiteralParselet);
+        $this->register(Tag::T_DOUBLE, new LiteralParselet);
+        $this->register(Tag::T_STRING, new LiteralParselet);
+        $this->register(Tag::T_IDENT, new NameParselet);
+        $this->register(Tag::T_THEN, new TernaryParselet);
+        $this->register('..', new RangeParselet);
+        $this->register('(', new GroupParselet);
+        $this->register('[', new CallParselet);
+        $this->register('{', new ArrayParselet);
+        $this->register('{', new AccessParselet);
+        $this->register(Tag::T_FN, new FunctionParselet);
+        $this->register(Tag::T_REQUIRE, new IncludeParselet);
+        $this->register(Tag::T_INCLUDE, new IncludeParselet);
+        $this->register('#', new NewParselet);
+        $this->register('.', new MemberAccessParselet);
+        $this->register('?.', new MemberAccessParselet);
+        $this->register(Tag::T_TRUE, new LiteralParselet);
+        $this->register(Tag::T_FALSE, new LiteralParselet);
+        $this->register(Tag::T_NIL, new LiteralParselet);
+        $this->register(Tag::T_ATOM, new LiteralParselet);
+        $this->register(Tag::T_WHEN, new WhenParselet);
 
-  public function position()
-  {
-    return ["line" => &$this->input->line, "column" => &$this->input->column];
-  }
+        $this->prefix('+', Precedence::PREFIX);
+        $this->prefix('-', Precedence::PREFIX);
+        $this->prefix('^^', Precedence::PREFIX);
+        $this->prefix('*', Precedence::PREFIX);
+        $this->prefix('@', Precedence::PREFIX);
+        $this->prefix('~', Precedence::PREFIX);
+        $this->prefix(Tag::T_NOT, Precedence::PREFIX);
 
-  public function infixParseletForToken(Token $token)
-  {
-    $key = $token->getTag();
-    return array_key_exists($key, $this->infix_parselets)
-      ? $this->infix_parselets[$key]
-      : NULL;
-  }
+        $this->postfix('!', Precedence::POSTFIX);
 
-  public function prefixParseletForToken(Token $token)
-  {
-    $key = $token->getTag();
-    return array_key_exists($key, $this->prefix_parselets)
-      ? $this->prefix_parselets[$key]
-      : NULL;
-  }
+        $this->infixLeft('+', Precedence::ADDITIVE);
+        $this->infixLeft('-', Precedence::ADDITIVE);
+        $this->infixLeft('++', Precedence::ADDITIVE);
+        $this->infixLeft('*', Precedence::MULTIPLICATIVE);
+        $this->infixLeft('/', Precedence::MULTIPLICATIVE);
+        $this->infixLeft(Tag::T_MOD, Precedence::MULTIPLICATIVE);
+        $this->infixLeft(Tag::T_AND, Precedence::LOGICAL_AND);
+        $this->infixLeft(Tag::T_OR, Precedence::LOGICAL_OR);
+        $this->infixLeft(Tag::T_XOR, Precedence::LOGICAL_XOR);
+        $this->infixLeft('|', Precedence::BITWISE_OR);
+        $this->infixLeft('&', Precedence::BITWISE_AND_OR_REF);
+        $this->infixLeft('^', Precedence::BITWISE_XOR);
+        $this->infixLeft('<<', Precedence::BITWISE_SHIFT);
+        $this->infixLeft('>>', Precedence::BITWISE_SHIFT);
+        $this->infixLeft('=', Precedence::VALUE_COMPARATOR);
+        $this->infixLeft('<>', Precedence::VALUE_COMPARATOR);
+        $this->infixLeft('<=', Precedence::SIZE_COMPARATOR);
+        $this->infixLeft('<', Precedence::SIZE_COMPARATOR);
+        $this->infixLeft('>=', Precedence::SIZE_COMPARATOR);
+        $this->infixLeft('>', Precedence::SIZE_COMPARATOR);
+        $this->infixLeft('|>', Precedence::PIPELINE);
+        $this->infixLeft('??', Precedence::COALESCENCE);
+        $this->infixLeft('?:', Precedence::TERNARY);
 
-  public function openScope()
-  {
-    $this->scope_level++;
-  }
+        $this->infixRight('**', Precedence::EXPONENT);
+        $this->infixRight(':-', Precedence::ASSIGNMENT);
+    }
 
-  public function closeScope()
-  {
-    $this->scope_level--;
-  }
+    public function match($tag)
+    {
+        if ($this->lookahead->getTag() === $tag) {
+            return $this->consume();
+        }
 
-  public function indent()
-  {
-    return str_repeat('  ', $this->scope_level);
-  }
+        throw (new SyntaxError)
+            -> expected($tag)
+            -> found($this->lookahead)
+            -> on($this->position())
+            -> source($this->input);
+    }
 
-  public function dedent()
-  {
-    return str_repeat('  ', $this->scope_level > 0 ? $this->scope_level - 1 : 0);
-  }
+    public function opt($tag)
+    {
+        if ($this->lookahead->getTag() === $tag) {
+            $pointer = $this->consume();
+            return $pointer === null ? true : $pointer;
+        }
+        return false;
+    }
+
+    public function is($tag)
+    {
+        return $this->lookahead->getTag() === $tag;
+    }
+
+    public function isOperator()
+    {
+        $op = $this->lookahead->getTag();
+        $op_table = array_values(Tag::getOpTable());
+        return in_array($op, $op_table, true);
+    }
+
+    public function consume()
+    {
+        $pointer = $this->lookahead === null ?: $this->lookahead->getPointer();
+        $this->lookahead = $this->input->nextToken();
+        return $pointer;
+    }
+
+    public function consumeAndFetch()
+    {
+        $clone = $this->lookahead;
+        $this->lookahead = $this->input->nextToken();
+        return $clone;
+    }
+
+    public function resolveScope($pointer)
+    {
+        return $this->input->getSymbolTable()->get($pointer);
+    }
+
+    public function position()
+    {
+        return ["line" => &$this->input->line, "column" => &$this->input->column];
+    }
+
+    public function infixParseletForToken(Token $token)
+    {
+        $key = $token->getTag();
+        return array_key_exists($key, $this->infix_parselets)
+            ? $this->infix_parselets[$key]
+            : null;
+    }
+
+    public function prefixParseletForToken(Token $token)
+    {
+        $key = $token->getTag();
+        return array_key_exists($key, $this->prefix_parselets)
+            ? $this->prefix_parselets[$key]
+            : null;
+    }
+
+    public function openScope()
+    {
+        $this->scope_level++;
+    }
+
+    public function closeScope()
+    {
+        $this->scope_level--;
+    }
+
+    public function indent()
+    {
+        return str_repeat('  ', $this->scope_level);
+    }
+
+    public function dedent()
+    {
+        return str_repeat('  ', $this->scope_level > 0 ? $this->scope_level - 1 : 0);
+    }
 }

--- a/src/parser/Precedence.php
+++ b/src/parser/Precedence.php
@@ -23,28 +23,28 @@ namespace QuackCompiler\Parser;
 
 class Precedence
 {
-  const ASSIGNMENT         = 1;
-  const PIPELINE           = 2;
-  const MEMBER_ACCESS      = 3;
-  const TERNARY            = 4;
-  const COALESCENCE        = 5;
-  const RANGE              = 6;
-  const LOGICAL_OR         = 7;
-  const LOGICAL_XOR        = 8;
-  const LOGICAL_AND        = 9;
-  const BITWISE_OR         = 10;
-  const BITWISE_XOR        = 11;
-  const BITWISE_AND_OR_REF = 12;
-  const VALUE_COMPARATOR   = 13;
-  const SIZE_COMPARATOR    = 14;
-  const BITWISE_SHIFT      = 15;
-  const ADDITIVE           = 16;
-  const MULTIPLICATIVE     = 17;
-  const PREFIX             = 18;
-  const POSTFIX            = 19;
-  const TYPE_CAST          = 20;
-  const EXPONENT           = 21;
-  const CALL               = 22;
-  const ACCESS             = 23;
-  // TODO: Review operators precedence when finish the parser
+    const ASSIGNMENT         = 1;
+    const PIPELINE           = 2;
+    const MEMBER_ACCESS      = 3;
+    const TERNARY            = 4;
+    const COALESCENCE        = 5;
+    const RANGE              = 6;
+    const LOGICAL_OR         = 7;
+    const LOGICAL_XOR        = 8;
+    const LOGICAL_AND        = 9;
+    const BITWISE_OR         = 10;
+    const BITWISE_XOR        = 11;
+    const BITWISE_AND_OR_REF = 12;
+    const VALUE_COMPARATOR   = 13;
+    const SIZE_COMPARATOR    = 14;
+    const BITWISE_SHIFT      = 15;
+    const ADDITIVE           = 16;
+    const MULTIPLICATIVE     = 17;
+    const PREFIX             = 18;
+    const POSTFIX            = 19;
+    const TYPE_CAST          = 20;
+    const EXPONENT           = 21;
+    const CALL               = 22;
+    const ACCESS             = 23;
+    // TODO: Review operators precedence when finish the parser
 }

--- a/src/parser/Quack.php
+++ b/src/parser/Quack.php
@@ -36,10 +36,10 @@ $lexer = new Tokenizer(file_get_contents('../../bootstrap/parser/Parser.qk'));
 $parser = new TokenReader($lexer);
 
 try {
-  $parser->parse();
-  $parser->dumpAst();
+    $parser->parse();
+    $parser->dumpAst();
 } catch (SyntaxError $e) {
-  echo $e;
+    echo $e;
 }
 
 echo PHP_EOL;

--- a/src/parser/SyntaxError.php
+++ b/src/parser/SyntaxError.php
@@ -39,88 +39,92 @@ define('END_BOLD', "\033[0m");
 
 class SyntaxError extends Exception
 {
-  private $expected;
-  private $found;
-  private $localization;
-  private $source;
+    private $expected;
+    private $found;
+    private $localization;
+    private $source;
 
-  public function expected($tag)
-  {
-    $this->expected = $tag;
-    return $this;
-  }
-
-  public function found(Token $token)
-  {
-    $this->found = $token;
-    return $this;
-  }
-
-  public function on(array $localization)
-  {
-    $this->localization = $localization;
-    return $this;
-  }
-
-  public function source($source)
-  {
-    $this->source = $source;
-    return $this;
-  }
-
-  private function extractSource()
-  {
-    $column = $this->localization['column'];
-    $line = $this->localization['line'];
-
-    $source_array = explode(PHP_EOL, $this->source->input);
-    $source_line = $source_array[$line];
-
-    $initial_column = $column - 10 <= 0
-      ? 0
-      : $this->localization['column'] - 10;
-
-    $buffer = [];
-
-    if ($line > 0) {
-      $buffer[] = BEGIN_GREEN . "{$line} | " . $source_array[$this->localization['line'] - 1] . PHP_EOL . END_GREEN;
+    public function expected($tag)
+    {
+        $this->expected = $tag;
+        return $this;
     }
 
-    $buffer[] = BEGIN_GREEN . ($line + 1) . " | ";
+    public function found(Token $token)
+    {
+        $this->found = $token;
+        return $this;
+    }
 
-    for ($i = $initial_column; $i < 70; $i++) {
-      if (isset($source_line[$i])) {
-        if ($i >= $column - $initial_column) {
-          $buffer[] = BEGIN_BG_RED . $source_line[$i] . END_BG_RED;
-        } else {
-            $buffer[] = BEGIN_GREEN . $source_line[$i] . END_GREEN;
+    public function on(array $localization)
+    {
+        $this->localization = $localization;
+        return $this;
+    }
+
+    public function source($source)
+    {
+        $this->source = $source;
+        return $this;
+    }
+
+    private function extractSource()
+    {
+        $column = $this->localization['column'];
+        $line = $this->localization['line'];
+
+        $source_array = explode(PHP_EOL, $this->source->input);
+        $source_line = $source_array[$line];
+
+        $initial_column = $column - 10 <= 0
+            ? 0
+            : $this->localization['column'] - 10;
+
+        $buffer = [];
+
+        if ($line > 0) {
+            $buffer[] = BEGIN_GREEN
+                . "{$line} | "
+                . $source_array[$this->localization['line'] - 1]
+                . PHP_EOL
+                . END_GREEN;
         }
-      }
+
+        $buffer[] = BEGIN_GREEN . ($line + 1) . " | ";
+
+        for ($i = $initial_column; $i < 70; $i++) {
+            if (isset($source_line[$i])) {
+                if ($i >= $column - $initial_column) {
+                    $buffer[] = BEGIN_BG_RED . $source_line[$i] . END_BG_RED;
+                } else {
+                    $buffer[] = BEGIN_GREEN . $source_line[$i] . END_GREEN;
+                }
+            }
+        }
+
+        $buffer[] = PHP_EOL . str_repeat(' ', $column - $initial_column + 1);
+        $buffer[] = BEGIN_BOLD . "^" . END_BOLD . str_repeat('^', 10);
+
+        return implode($buffer);
     }
 
-    $buffer[] = PHP_EOL . str_repeat(' ', $column - $initial_column + 1);
-    $buffer[] = BEGIN_BOLD . "^" . END_BOLD . str_repeat('^', 10);
+    public function __toString()
+    {
+        $source = $this->extractSource();
 
-    return implode($buffer);
-  }
+        $expected = is_integer($this->expected) ? Tag::getName($this->expected) : $this->expected;
+        $found = $this->found->getTag() === 0
+            ? "end of the source"
+            : Tag::getName($this->found->getTag()) ?: $this->found->getTag();
 
-  public function __toString()
-  {
-    $source = $this->extractSource();
-
-    $expected = is_integer($this->expected) ? Tag::getName($this->expected) : $this->expected;
-    $found = $this->found->getTag() === 0
-      ? "end of the source"
-      : Tag::getName($this->found->getTag()) ?: $this->found->getTag();
-
-    return $this->extractSource() . PHP_EOL . implode(PHP_EOL, [
-      BEGIN_ORANGE,
-      "*** You have a syntactic error in your code!",
-      "    Expecting [{$expected}]",
-      "    Found     [{$found}]",
-      "    Line      {$this->localization['line']}",
-      "    Column    {$this->localization['column']}",
-      END_ORANGE
-    ]);
-  }
+        return $this->extractSource() . PHP_EOL . implode(PHP_EOL, [
+            BEGIN_ORANGE,
+            "*** You have a syntactic error in your code!",
+            "    Expecting [{$expected}]",
+            "    Found     [{$found}]",
+            "    Line      {$this->localization['line']}",
+            "    Column    {$this->localization['column']}",
+            END_ORANGE
+        ]);
+    }
 }

--- a/src/parser/TokenChecker.php
+++ b/src/parser/TokenChecker.php
@@ -65,7 +65,6 @@ class TokenChecker
             || $this->parser->is(Tag::T_GOTO)     // Done
             || $this->parser->is(Tag::T_GLOBAL)   // Done
             || $this->parser->is(Tag::T_RAISE)    // Done
-            || $this->parser->is(Tag::T_PRINT)    // Done
             || $this->parser->is(Tag::T_BEGIN)    // Done
             || $this->parser->is('^')             // Done
             || $this->parser->is(':-');           // Done

--- a/src/parser/TokenChecker.php
+++ b/src/parser/TokenChecker.php
@@ -25,99 +25,99 @@ use \QuackCompiler\Lexer\Tag;
 
 class TokenChecker
 {
-  private $parser;
+    private $parser;
 
-  function __construct(TokenReader $parser)
-  {
-    $this->parser = $parser;
-  }
+    public function __construct(TokenReader $parser)
+    {
+        $this->parser = $parser;
+    }
 
-  function startsTopStmt()
-  {
-    return $this->startsStmt()
-        || $this->startsClassDeclStmt()
-        || $this->parser->is(Tag::T_STRUCT)
-        || $this->parser->is(Tag::T_FN)
-        || $this->parser->is(Tag::T_MODULE)
-        || $this->parser->is(Tag::T_OPEN)
-        || $this->parser->is(Tag::T_CONST);
-  }
+    public function startsTopStmt()
+    {
+        return $this->startsStmt()
+            || $this->startsClassDeclStmt()
+            || $this->parser->is(Tag::T_STRUCT)
+            || $this->parser->is(Tag::T_FN)
+            || $this->parser->is(Tag::T_MODULE)
+            || $this->parser->is(Tag::T_OPEN)
+            || $this->parser->is(Tag::T_CONST);
+    }
 
-  function startsInnerStmt()
-  {
-    return $this->startsStmt()
-        || $this->parser->is(Tag::T_FN)
-        || $this->startsClassDeclStmt();
-  }
+    public function startsInnerStmt()
+    {
+        return $this->startsStmt()
+            || $this->parser->is(Tag::T_FN)
+            || $this->startsClassDeclStmt();
+    }
 
-  function startsStmt()
-  {
-    return $this->parser->is(Tag::T_IF)       // Done
-        || $this->parser->is(Tag::T_LET)      // Done
-        || $this->parser->is(Tag::T_WHILE)    // Done
-        || $this->parser->is(Tag::T_DO)       // Done
-        || $this->parser->is(Tag::T_FOR)      // Done
-        || $this->parser->is(Tag::T_FOREACH)  // Done
-        || $this->parser->is(Tag::T_SWITCH)   // Done
-        || $this->parser->is(Tag::T_TRY)      // Done
-        || $this->parser->is(Tag::T_BREAK)    // Done
-        || $this->parser->is(Tag::T_CONTINUE) // Done
-        || $this->parser->is(Tag::T_GOTO)     // Done
-        || $this->parser->is(Tag::T_GLOBAL)   // Done
-        || $this->parser->is(Tag::T_RAISE)    // Done
-        || $this->parser->is(Tag::T_PRINT)    // Done
-        || $this->parser->is(Tag::T_BEGIN)    // Done
-        || $this->parser->is('^')             // Done
-        || $this->parser->is(':-');           // Done
-  }
+    public function startsStmt()
+    {
+        return $this->parser->is(Tag::T_IF)       // Done
+            || $this->parser->is(Tag::T_LET)      // Done
+            || $this->parser->is(Tag::T_WHILE)    // Done
+            || $this->parser->is(Tag::T_DO)       // Done
+            || $this->parser->is(Tag::T_FOR)      // Done
+            || $this->parser->is(Tag::T_FOREACH)  // Done
+            || $this->parser->is(Tag::T_SWITCH)   // Done
+            || $this->parser->is(Tag::T_TRY)      // Done
+            || $this->parser->is(Tag::T_BREAK)    // Done
+            || $this->parser->is(Tag::T_CONTINUE) // Done
+            || $this->parser->is(Tag::T_GOTO)     // Done
+            || $this->parser->is(Tag::T_GLOBAL)   // Done
+            || $this->parser->is(Tag::T_RAISE)    // Done
+            || $this->parser->is(Tag::T_PRINT)    // Done
+            || $this->parser->is(Tag::T_BEGIN)    // Done
+            || $this->parser->is('^')             // Done
+            || $this->parser->is(':-');           // Done
+    }
 
-  function startsExpr()
-  {
-    return $this->parser->is(Tag::T_INTEGER)
-        || $this->parser->is(Tag::T_DOUBLE)
-        || $this->parser->is(Tag::T_FN)
-        || $this->parser->is(Tag::T_REQUIRE)
-        || $this->parser->is(Tag::T_INCLUDE)
-        || $this->parser->is(Tag::T_IDENT)
-        || $this->parser->is(Tag::T_TRUE)
-        || $this->parser->is(Tag::T_FALSE)
-        || $this->parser->is(Tag::T_NIL)
-        || $this->parser->is(Tag::T_WHEN)
-        || $this->parser->is(Tag::T_STRING)
-        || $this->parser->is(Tag::T_ATOM)
-        || $this->parser->isOperator()
-        || $this->parser->is('{')
-        || $this->parser->is('(');
-  }
+    public function startsExpr()
+    {
+        return $this->parser->is(Tag::T_INTEGER)
+            || $this->parser->is(Tag::T_DOUBLE)
+            || $this->parser->is(Tag::T_FN)
+            || $this->parser->is(Tag::T_REQUIRE)
+            || $this->parser->is(Tag::T_INCLUDE)
+            || $this->parser->is(Tag::T_IDENT)
+            || $this->parser->is(Tag::T_TRUE)
+            || $this->parser->is(Tag::T_FALSE)
+            || $this->parser->is(Tag::T_NIL)
+            || $this->parser->is(Tag::T_WHEN)
+            || $this->parser->is(Tag::T_STRING)
+            || $this->parser->is(Tag::T_ATOM)
+            || $this->parser->isOperator()
+            || $this->parser->is('{')
+            || $this->parser->is('(');
+    }
 
-  function startsClassDeclStmt()
-  {
-    return $this->parser->is(Tag::T_CLASS);
-  }
+    public function startsClassDeclStmt()
+    {
+        return $this->parser->is(Tag::T_CLASS);
+    }
 
-  function startsParameter()
-  {
-    return $this->parser->is('...')
-        || $this->parser->is('*')
-        || $this->parser->is(Tag::T_IDENT);
-  }
+    public function startsParameter()
+    {
+        return $this->parser->is('...')
+            || $this->parser->is('*')
+            || $this->parser->is(Tag::T_IDENT);
+    }
 
-  function startsCase()
-  {
-    return $this->parser->is(Tag::T_CASE)
-        || $this->parser->is(Tag::T_ELSE);
-  }
+    public function startsCase()
+    {
+        return $this->parser->is(Tag::T_CASE)
+            || $this->parser->is(Tag::T_ELSE);
+    }
 
-  function startsClassStmt()
-  {
-    return $this->parser->is(Tag::T_FN)
-        || $this->parser->is(Tag::T_CONST)
-        || $this->parser->is(Tag::T_OPEN)
-        || $this->parser->is(Tag::T_IDENT);
-  }
+    public function startsClassStmt()
+    {
+        return $this->parser->is(Tag::T_FN)
+            || $this->parser->is(Tag::T_CONST)
+            || $this->parser->is(Tag::T_OPEN)
+            || $this->parser->is(Tag::T_IDENT);
+    }
 
-  function isEoF()
-  {
-    return $this->parser->lookahead->getTag() === 0;
-  }
+    public function isEoF()
+    {
+        return $this->parser->lookahead->getTag() === 0;
+    }
 }

--- a/src/parser/TokenReader.php
+++ b/src/parser/TokenReader.php
@@ -45,43 +45,43 @@ use \QuackCompiler\Ast\Helper\Param;
 
 class TokenReader extends Parser
 {
-  public $ast = [];
-  public $grammar;
+    public $ast = [];
+    public $grammar;
 
-  public function __construct(Tokenizer $input)
-  {
-    parent::__construct($input);
-    $this->grammar = new Grammar($this);
-  }
-
-  /* Handlers */
-  public function dumpAst()
-  {
-    foreach ($this->input->symbol_table->iterator() as $key => $value) {
-      echo '[', BEGIN_GREEN, $key, END_GREEN, ': ', BEGIN_BOLD,  $value, END_BOLD, ']', PHP_EOL;
+    public function __construct(Tokenizer $input)
+    {
+        parent::__construct($input);
+        $this->grammar = new Grammar($this);
     }
 
-    var_dump($this->ast);
-  }
+    /* Handlers */
+    public function dumpAst()
+    {
+        foreach ($this->input->symbol_table->iterator() as $key => $value) {
+            echo '[', BEGIN_GREEN, $key, END_GREEN, ': ', BEGIN_BOLD,  $value, END_BOLD, ']', PHP_EOL;
+        }
 
-  public function format()
-  {
-    foreach ($this->ast as $stmt) {
-      echo $stmt->format($this);
+        var_dump($this->ast);
     }
-  }
 
-  public function beautify()
-  {
-    $source = [];
-    foreach ($this->ast as $stmt) {
-      $source[] = $stmt->format($this);
+    public function format()
+    {
+        foreach ($this->ast as $stmt) {
+            echo $stmt->format($this);
+        }
     }
-    return implode($source);
-  }
 
-  public function parse()
-  {
-    $this->ast = $this->grammar->start();
-  }
+    public function beautify()
+    {
+        $source = [];
+        foreach ($this->ast as $stmt) {
+            $source[] = $stmt->format($this);
+        }
+        return implode($source);
+    }
+
+    public function parse()
+    {
+        $this->ast = $this->grammar->start();
+    }
 }

--- a/src/repl/QuackRepl.php
+++ b/src/repl/QuackRepl.php
@@ -28,92 +28,92 @@ use \QuackCompiler\Parser\TokenReader;
 
 function start_repl()
 {
-  echo <<<LICENSE
+    echo <<<LICENSE
 Quack · Copyright (C) 2016 Marcelo Camargo
 This program comes with ABSOLUTELY NO WARRANTY.
 This is free software, and you are welcome to redistribute it
 under certain conditions; type 'show c' for details.\n
 LICENSE
-;
-  echo "Use quack --help for more information", PHP_EOL;
+    ;
+    echo "Use quack --help for more information", PHP_EOL;
 
-  if (args_have('-h', '--help')) {
-    open_repl_help();
-    return;
-  }
+    if (args_have('-h', '--help')) {
+        open_repl_help();
+        return;
+    }
 
-  repl();
+    repl();
 }
 
 function install_stream_handler()
 {
-  echo "\033[01;36m";
-  readline_callback_handler_install("Quack> ", 'readline_callback');
-  echo "\033[0m";
+    echo "\033[01;36m";
+    readline_callback_handler_install("Quack> ", 'readline_callback');
+    echo "\033[0m";
 }
 
 function print_entire_license()
 {
-  echo file_get_contents(__DIR__ . "/../../LICENSE.md");
+    echo file_get_contents(__DIR__ . "/../../LICENSE.md");
 }
 
 function readline_callback($command)
 {
-  $command = trim($command);
+    $command = trim($command);
 
-  if ($command === ':quit' || $command === ':q') {
-    exit;
-  } else if ($command === 'show c') {
-    print_entire_license();
-    goto next;
-  } else if ($command === '') {
-    goto next;
-  } else if ($command === ':clear') {
-    $clear = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? 'cls' : 'clear';
-    system($clear);
-    goto next;
-  }
+    if ($command === ':quit' || $command === ':q') {
+        exit;
+    } elseif ($command === 'show c') {
+        print_entire_license();
+        goto next;
+    } elseif ($command === '') {
+        goto next;
+    } elseif ($command === ':clear') {
+        $clear = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? 'cls' : 'clear';
+        system($clear);
+        goto next;
+    }
 
-  $lexer = new Tokenizer($command);
-  $parser = new TokenReader($lexer);
+    $lexer = new Tokenizer($command);
+    $parser = new TokenReader($lexer);
 
-  try {
-    $parser->parse();
-    /* when */ args_have('-a', '--ast') && $parser->dumpAst();
-  } catch (SyntaxError $e) {
-    echo $e;
-  }
+    try {
+        $parser->parse();
+        /* when */ args_have('-a', '--ast') && $parser->dumpAst();
+    } catch (SyntaxError $e) {
+        echo $e;
+    }
 
-  next:
-  readline_add_history($command);
-  install_stream_handler();
+    next:
+    readline_add_history($command);
+    install_stream_handler();
 }
 
 function repl()
 {
-  echo "Type ^C or :quit to leave", PHP_EOL;
-  install_stream_handler();
+    echo "Type ^C or :quit to leave", PHP_EOL;
+    install_stream_handler();
 
-  while (true) {
-    $write = NULL;
-    $except = NULL;
-    $stream = stream_select($read = [STDIN], $write, $except, NULL);
+    while (true) {
+        $write = null;
+        $except = null;
+        $stream = stream_select($read = [STDIN], $write, $except, null);
 
-    if ($stream && in_array(STDIN, $read)) {
-      readline_callback_read_char();
+        if ($stream && in_array(STDIN, $read)) {
+            readline_callback_read_char();
+        }
     }
-  }
 }
 
 function open_repl_help()
 {
-  // TODO
+    // TODO
 }
 
 function args_have()
 {
-  global $argv;
-  return count(array_intersect($argv, func_get_args())) > 0;
+    global $argv;
+    return count(array_intersect($argv, func_get_args())) > 0;
 }
 
 start_repl();

--- a/src/toolkit/QuackToolkit.php
+++ b/src/toolkit/QuackToolkit.php
@@ -26,7 +26,7 @@ define('PARSER', 'parser');
 
 function import($module, $file)
 {
-  require_once BASE_PATH . '/' . $module . '/' . $file . '.php';
+    require_once BASE_PATH . '/' . $module . '/' . $file . '.php';
 }
 
 /* Lexer */

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -111,14 +111,14 @@ class LexerTest extends \PHPUnit_Framework_TestCase
             "init", "self", "module", "class", "goto", "foreach", "in", "where",
             "const", "nil", "open", "global", "as", "enum", "continue", "switch",
             "break", "and", "or", "xor", "try", "rescue", "finally", "raise", "elif",
-            "else", "case", "super", "is", "deriving", "print", "not"
+            "else", "case", "super", "is", "deriving", "not"
         ];
 
         $this->assertEquals(
             "[true][false][let][if][for][while][do][struct]" .
             "[init][self][module][class][goto][foreach][in][where][const][nil]" .
             "[open][global][as][enum][continue][switch][break][and][or][xor][try]" .
-            "[rescue][finally][raise][elif][else][case][super][is][deriving][print]" .
+            "[rescue][finally][raise][elif][else][case][super][is][deriving]" .
             "[not]",
             $this->tokenize(implode(' ', $keywords))
         );

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -8,7 +8,7 @@ use \QuackCompiler\Lexer\Tokenizer;
 
 define('SHOW_SYMBOL_TABLE', true);
 
-class LexerTest extends PHPUnit_Framework_TestCase
+class LexerTest extends \PHPUnit_Framework_TestCase
 {
     private function tokenize($source, $show_symbol_table = false)
     {

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -1,4 +1,6 @@
 <?php
+namespace QuackCompiler\Tests;
+
 define('BASE_PATH', __DIR__ . '/../src');
 require_once './src/toolkit/QuackToolkit.php';
 
@@ -8,93 +10,126 @@ define('SHOW_SYMBOL_TABLE', true);
 
 class LexerTest extends PHPUnit_Framework_TestCase
 {
-  private function tokenize($source, $show_symbol_table = false)
-  {
-    return implode(array_map(function($token) use ($show_symbol_table) {
-      return (string) $token;
-    }, (new Tokenizer($source))->eagerlyEvaluate($show_symbol_table)));
-  }
+    private function tokenize($source, $show_symbol_table = false)
+    {
+        return implode(array_map(function ($token) use ($show_symbol_table) {
+            return (string) $token;
+        }, (new Tokenizer($source))->eagerlyEvaluate($show_symbol_table)));
+    }
 
-  public function testIdent()
-  {
-    $this->assertEquals("[T_IDENT, 0]", $this->tokenize('quack'));
-    $this->assertEquals("[T_IDENT, quack]", $this->tokenize('quack', SHOW_SYMBOL_TABLE));
-    $this->assertEquals("[T_IDENT, 0][T_IDENT, 1]", $this->tokenize('hello world'));
-    $this->assertEquals("[T_IDENT, hello][T_IDENT, world]", $this->tokenize('hello world', SHOW_SYMBOL_TABLE));
-  }
+    public function testIdent()
+    {
+        $this->assertEquals("[T_IDENT, 0]", $this->tokenize('quack'));
+        $this->assertEquals("[T_IDENT, quack]", $this->tokenize('quack', SHOW_SYMBOL_TABLE));
+        $this->assertEquals("[T_IDENT, 0][T_IDENT, 1]", $this->tokenize('hello world'));
+        $this->assertEquals("[T_IDENT, hello][T_IDENT, world]", $this->tokenize('hello world', SHOW_SYMBOL_TABLE));
+    }
 
-  public function testNumber()
-  {
-    $decimal_integer = "1083";
-    $octal_integer = "0314";
-    $octal_partial_integer = "0314891";
-    $hexa_integer = "0xFFAB01";
-    $decimal_double = "124.1323";
-    $decimal_non_octal_double = "0314.0";
-    $binary_integer = "0b11111111";
-    $binary_invalid = "0b1019";
+    public function testNumber()
+    {
+        $decimal_integer = "1083";
+        $octal_integer = "0314";
+        $octal_partial_integer = "0314891";
+        $hexa_integer = "0xFFAB01";
+        $decimal_double = "124.1323";
+        $decimal_non_octal_double = "0314.0";
+        $binary_integer = "0b11111111";
+        $binary_invalid = "0b1019";
 
-    $this->assertEquals("[T_INTEGER, 1083]", $this->tokenize($decimal_integer, SHOW_SYMBOL_TABLE));
-    $this->assertEquals("[T_INTEGER, 0314]", $this->tokenize($octal_integer, SHOW_SYMBOL_TABLE));
-    $this->assertEquals("[T_INTEGER, 0314]", $this->tokenize($octal_partial_integer, SHOW_SYMBOL_TABLE));
-    $this->assertEquals("[T_INTEGER, 0xFFAB01]", $this->tokenize($hexa_integer, SHOW_SYMBOL_TABLE));
-    $this->assertEquals("[T_DOUBLE, 124.1323]", $this->tokenize($decimal_double, SHOW_SYMBOL_TABLE));
-    $this->assertEquals("[T_DOUBLE, 0314.0]", $this->tokenize($decimal_non_octal_double, SHOW_SYMBOL_TABLE));
-    $this->assertEquals("[T_INTEGER, 0b11111111]", $this->tokenize($binary_integer, SHOW_SYMBOL_TABLE));
-    $this->assertEquals("[T_INTEGER, 0b101][T_INTEGER, 9]", $this->tokenize($binary_invalid, SHOW_SYMBOL_TABLE));
-  }
+        $this->assertEquals("[T_INTEGER, 1083]", $this->tokenize($decimal_integer, SHOW_SYMBOL_TABLE));
+        $this->assertEquals("[T_INTEGER, 0314]", $this->tokenize($octal_integer, SHOW_SYMBOL_TABLE));
+        $this->assertEquals("[T_INTEGER, 0314]", $this->tokenize($octal_partial_integer, SHOW_SYMBOL_TABLE));
+        $this->assertEquals("[T_INTEGER, 0xFFAB01]", $this->tokenize($hexa_integer, SHOW_SYMBOL_TABLE));
+        $this->assertEquals("[T_DOUBLE, 124.1323]", $this->tokenize($decimal_double, SHOW_SYMBOL_TABLE));
+        $this->assertEquals("[T_DOUBLE, 0314.0]", $this->tokenize($decimal_non_octal_double, SHOW_SYMBOL_TABLE));
+        $this->assertEquals("[T_INTEGER, 0b11111111]", $this->tokenize($binary_integer, SHOW_SYMBOL_TABLE));
+        $this->assertEquals("[T_INTEGER, 0b101][T_INTEGER, 9]", $this->tokenize($binary_invalid, SHOW_SYMBOL_TABLE));
+    }
 
-  public function testSemanticComment()
-  {
-    $partial_function = "&(* 1)";
-    $semantic_comment = "(* Some comment *)";
+    public function testSemanticComment()
+    {
+        $partial_function = "&(* 1)";
+        $semantic_comment = "(* Some comment *)";
 
-    $this->assertEquals("[&(][*][T_INTEGER, 1][)]", $this->tokenize($partial_function, SHOW_SYMBOL_TABLE));
-    $this->assertEquals("[T_SEMANTIC_COMMENT,  Some comment ]", $this->tokenize($semantic_comment, SHOW_SYMBOL_TABLE));
-    $this->assertEquals("[T_SEMANTIC_COMMENT, 0]", $this->tokenize($semantic_comment));
-  }
+        $this->assertEquals(
+            "[&(][*][T_INTEGER, 1][)]",
+            $this->tokenize($partial_function, SHOW_SYMBOL_TABLE)
+        );
+        $this->assertEquals(
+            "[T_SEMANTIC_COMMENT,  Some comment ]",
+            $this->tokenize($semantic_comment, SHOW_SYMBOL_TABLE)
+        );
+        $this->assertEquals(
+            "[T_SEMANTIC_COMMENT, 0]",
+            $this->tokenize($semantic_comment)
+        );
+    }
 
-  public function testString()
-  {
-    $string = "'lorem ipsum dolor'";
-    $string_with_quote = "'lorem ipsum \' dolor'";
-    $string_with_double_quote = "'lorem ipsum \" dolor";
-    $complex_string = '"complex \" string"';
-    $simple_string = '"simple \' string"';
+    public function testString()
+    {
+        $string = "'lorem ipsum dolor'";
+        $string_with_quote = "'lorem ipsum \' dolor'";
+        $string_with_double_quote = "'lorem ipsum \" dolor";
+        $complex_string = '"complex \" string"';
+        $simple_string = '"simple \' string"';
 
-    $this->assertEquals('[T_STRING, lorem ipsum dolor]', $this->tokenize($string, SHOW_SYMBOL_TABLE));
-    $this->assertEquals('[T_STRING, lorem ipsum \\\' dolor]', $this->tokenize($string_with_quote, SHOW_SYMBOL_TABLE));
-    $this->assertEquals('[T_STRING, lorem ipsum " dolor]', $this->tokenize($string_with_double_quote, SHOW_SYMBOL_TABLE));
-    $this->assertEquals('[T_STRING, complex \\" string]', $this->tokenize($complex_string, SHOW_SYMBOL_TABLE));
-    $this->assertEquals('[T_STRING, simple \' string]', $this->tokenize($simple_string, SHOW_SYMBOL_TABLE));
-  }
+        $this->assertEquals(
+            '[T_STRING, lorem ipsum dolor]',
+            $this->tokenize($string, SHOW_SYMBOL_TABLE)
+        );
+        $this->assertEquals(
+            '[T_STRING, lorem ipsum \\\' dolor]',
+            $this->tokenize($string_with_quote, SHOW_SYMBOL_TABLE)
+        );
+        $this->assertEquals(
+            '[T_STRING, lorem ipsum " dolor]',
+            $this->tokenize($string_with_double_quote, SHOW_SYMBOL_TABLE)
+        );
+        $this->assertEquals(
+            '[T_STRING, complex \\" string]',
+            $this->tokenize($complex_string, SHOW_SYMBOL_TABLE)
+        );
+        $this->assertEquals(
+            '[T_STRING, simple \' string]',
+            $this->tokenize($simple_string, SHOW_SYMBOL_TABLE)
+        );
+    }
 
-  public function testParam()
-  {
-    $some_parameters = "&0, &1, &(2)";
-    $this->assertEquals("[T_PARAM, 0][,][T_PARAM, 1][,][&(][T_INTEGER, 2][)]", $this->tokenize($some_parameters, SHOW_SYMBOL_TABLE));
-  }
+    public function testParam()
+    {
+        $some_parameters = "&0, &1, &(2)";
+        $this->assertEquals(
+            "[T_PARAM, 0][,][T_PARAM, 1][,][&(][T_INTEGER, 2][)]",
+            $this->tokenize($some_parameters, SHOW_SYMBOL_TABLE)
+        );
+    }
 
-  public function testKeywords()
-  {
-    $keywords = ["true", "false", "let", "if", "for", "while", "do", "struct",
-      "init", "self", "module", "class", "goto", "foreach", "in", "where",
-      "const", "nil", "open", "global", "as", "enum", "continue", "switch",
-      "break", "and", "or", "xor", "try", "rescue", "finally", "raise", "elif",
-      "else", "case", "super", "is", "deriving", "print", "not"
-    ];
+    public function testKeywords()
+    {
+        $keywords = [
+            "true", "false", "let", "if", "for", "while", "do", "struct",
+            "init", "self", "module", "class", "goto", "foreach", "in", "where",
+            "const", "nil", "open", "global", "as", "enum", "continue", "switch",
+            "break", "and", "or", "xor", "try", "rescue", "finally", "raise", "elif",
+            "else", "case", "super", "is", "deriving", "print", "not"
+        ];
 
-    $this->assertEquals("[true][false][let][if][for][while][do][struct]" .
-      "[init][self][module][class][goto][foreach][in][where][const][nil]" .
-      "[open][global][as][enum][continue][switch][break][and][or][xor][try]" .
-      "[rescue][finally][raise][elif][else][case][super][is][deriving][print]" .
-      "[not]", $this->tokenize(implode(' ', $keywords)));
-  }
+        $this->assertEquals(
+            "[true][false][let][if][for][while][do][struct]" .
+            "[init][self][module][class][goto][foreach][in][where][const][nil]" .
+            "[open][global][as][enum][continue][switch][break][and][or][xor][try]" .
+            "[rescue][finally][raise][elif][else][case][super][is][deriving][print]" .
+            "[not]",
+            $this->tokenize(implode(' ', $keywords))
+        );
+    }
 
-  public function testOperators()
-  {
-    $this->assertEquals("[-][T_INTEGER, 0][*][T_INTEGER, 1][and]" .
-      "[T_INTEGER, 2][or][T_INTEGER, 3][++][T_INTEGER, 4][;][@][T_IDENT, 5]",
-      $this->tokenize("-1 * 3 and 2 or 4 ++ 8; @name"));
-  }
+    public function testOperators()
+    {
+        $this->assertEquals(
+            "[-][T_INTEGER, 0][*][T_INTEGER, 1][and]" .
+            "[T_INTEGER, 2][or][T_INTEGER, 3][++][T_INTEGER, 4][;][@][T_IDENT, 5]",
+            $this->tokenize("-1 * 3 and 2 or 4 ++ 8; @name")
+        );
+    }
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1,4 +1,6 @@
 <?php
+namespace QuackCompiler\Tests;
+
 define('BASE_PATH', __DIR__ . '/../src');
 require_once './src/toolkit/QuackToolkit.php';
 
@@ -7,37 +9,37 @@ use \QuackCompiler\Parser\TokenReader;
 
 class ParserTest extends PHPUnit_Framework_TestCase
 {
-  public function testProvideBeautifier()
-  {
-    return function ($source) {
-      $lexer = new Tokenizer($source);
-      $parser = new TokenReader($lexer);
-      $parser->parse();
-      return $parser->beautify();
-    };
-  }
+    public function testProvideBeautifier()
+    {
+        return function ($source) {
+            $lexer = new Tokenizer($source);
+            $parser = new TokenReader($lexer);
+            $parser->parse();
+            return $parser->beautify();
+        };
+    }
 
-  /**
-   * @depends testProvideBeautifier
-   */
-  public function testBreakStmt($beautifier)
-  {
-    $break = "break";
-    $break_expr = "break 10";
+    /**
+     * @depends testProvideBeautifier
+     */
+    public function testBreakStmt($beautifier)
+    {
+        $break = "break";
+        $break_expr = "break 10";
 
-    $this->assertEquals("break\n", $beautifier($break));
-    $this->assertEquals("break 10\n", $beautifier($break_expr));
-  }
+        $this->assertEquals("break\n", $beautifier($break));
+        $this->assertEquals("break 10\n", $beautifier($break_expr));
+    }
 
-  /**
-   * @depends testProvideBeautifier
-   */
-  public function testContinueStmt($beautifier)
-  {
-    $continue = "continue";
-    $continue_expr = "continue 10";
+    /**
+     * @depends testProvideBeautifier
+     */
+    public function testContinueStmt($beautifier)
+    {
+        $continue = "continue";
+        $continue_expr = "continue 10";
 
-    $this->assertEquals("continue\n", $beautifier($continue));
-    $this->assertEquals("continue 10\n", $beautifier($continue_expr));
-  }
+        $this->assertEquals("continue\n", $beautifier($continue));
+        $this->assertEquals("continue 10\n", $beautifier($continue_expr));
+    }
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -7,7 +7,7 @@ require_once './src/toolkit/QuackToolkit.php';
 use \QuackCompiler\Lexer\Tokenizer;
 use \QuackCompiler\Parser\TokenReader;
 
-class ParserTest extends PHPUnit_Framework_TestCase
+class ParserTest extends \PHPUnit_Framework_TestCase
 {
     public function testProvideBeautifier()
     {

--- a/tools/phpcs-pre-commit/README.md
+++ b/tools/phpcs-pre-commit/README.md
@@ -1,0 +1,20 @@
+### PHP PHPCodeSniffer with PSR-2 Standard (pre-commit hook)
+In order to make ```Quack```'s development easier, it is required you to install this __PSR-2__ hook for ```git```. This tool __evaluates__ the quality of your code together with the ```phpcs```. 
+
+That will help us to make better code and reduce code refactoring in the future.
+
+### Requirements
+- ```Bash```
+- ```PHPCodeSniffer```
+
+### How to install
+
+- ```cd path/to/quack/tools/phpcs-pre-commit```
+- ```bash install.sh```
+ 
+### How to use
+That happens automatically when you commit your code.
+
+### Problems? Sugestions?
+[https://github.com/luizperes/pre-commit](https://github.com/luizperes/pre-commit)
+

--- a/tools/phpcs-pre-commit/install.sh
+++ b/tools/phpcs-pre-commit/install.sh
@@ -1,0 +1,15 @@
+arr_program=(git phpcs)
+
+for program in ${arr_program[@]} 
+do
+  condition=$(which $program 2>/dev/null | grep -v "not found" | wc -l)
+  if [ $condition -eq 0 ] ; then
+      echo "You are required to install '$program'"
+      exit
+  fi
+done
+
+git clone https://github.com/luizperes/pre-commit.git 
+mv pre-commit/pre-commit ../../.git/hooks/pre-commit
+chmod +x ../../.git/hooks/pre-commit
+rm -rf pre-commit


### PR DESCRIPTION
This PR is related to the issue [#9](https://github.com/quack/quack/issues/9).

What does it have?
- [x] Applies PSR-2 to **all PHP files** under `src` and `test`
- [x] Fixes **all** PSR-2 `MUSTs`
- [x] Adds a `pre-commit` hook under the folder `/path/to/quack/tools/phpcs-pre-commit`
- [x] Changes the `CONTRIBUTING.md` file.
- [x] makes the use of `PHPCodeSniffer` and `PSR-2 coding style standard` mandatory to all of us.

What is still missing?
- We still need to **fix** all PSR-2 `SHOULDs`. (After installing `phpcs`, run the command  `phpcs --standard=PSR2 /path/to/quack`
- Code refactoring for all PSR-2 `SHOULDs`.

Obs.: The pre-commit only prevents you to commit if you do not follow PSR-2 `MUSTs` (a.k.a. errors). For warnings(a.k.a. SHOULDs), it will allow you to commit normally.  
