### PR TITLE
Absolute path quick-fix in QuackRepl.php

### DIFF
--- a/src/repl/QuackRepl.php
+++ b/src/repl/QuackRepl.php
@@ -20,7 +20,7 @@
  * along with Quack.  If not, see <http://www.gnu.org/licenses/>.
  */
 define('BASE_PATH', __DIR__ . '/..');
-require_once(BASE_PATH.'/toolkit/QuackToolkit.php');
+require_once(BASE_PATH . '/toolkit/QuackToolkit.php');
 
 use \QuackCompiler\Lexer\Tokenizer;
 use \QuackCompiler\Parser\SyntaxError;

--- a/src/repl/QuackRepl.php
+++ b/src/repl/QuackRepl.php
@@ -20,7 +20,7 @@
  * along with Quack.  If not, see <http://www.gnu.org/licenses/>.
  */
 define('BASE_PATH', __DIR__ . '/..');
-require_once '../toolkit/QuackToolkit.php';
+require_once(BASE_PATH.'/toolkit/QuackToolkit.php');
 
 use \QuackCompiler\Lexer\Tokenizer;
 use \QuackCompiler\Parser\SyntaxError;


### PR DESCRIPTION
Added BASE_PATH to the QuackToolkit import in QuackRepl.php. The previous version wouldn't work in one of my PCs and this fix makes it clear where the file is.
