### PR TITLE
Refactored how the compiler deals with operators

### DIFF
--- a/src/ast/expr/OperatorExpr.php
+++ b/src/ast/expr/OperatorExpr.php
@@ -39,13 +39,6 @@ class OperatorExpr implements Expr
 
     public function format(Parser $parser)
     {
-        $string_builder = ['('];
-        $string_builder[] = $this->left->format($parser);
-        $string_builder[] = ' ';
-        $string_builder[] = Tag::getPunctuator($this->operator);
-        $string_builder[] = ' ';
-        $string_builder[] = $this->right->format($parser);
-        $string_builder[] = ')';
-        return implode($string_builder);
+        throw new \Exception;
     }
 }

--- a/src/ast/expr/PostfixExpr.php
+++ b/src/ast/expr/PostfixExpr.php
@@ -37,10 +37,6 @@ class PostfixExpr implements Expr
 
     public function format(Parser $parser)
     {
-        $string_builder = ['('];
-        $string_builder[] = $this->left->format($parser);
-        $string_builder[] = Tag::getPunctuator($this->operator);
-        $string_builder[] = ')';
-        return implode($string_builder);
+        throw new \Exception;
     }
 }

--- a/src/lexer/Tag.php
+++ b/src/lexer/Tag.php
@@ -89,140 +89,21 @@ class Tag
     const T_WHEN = 306;
     const T_UNLESS = 307;
 
-    /* Operators */
-
-    # <
-    const T_LESSER              = 1000; # <
-    const T_RETURN              = 1001; # <<<
-    const T_BITWISE_SHIFT_LEFT  = 1002; # <<
-    const T_DIFFERENT           = 1003; # <>
-    const T_LESSER_OR_EQUAL     = 1004; # <=
-
-    # >
-    const T_GREATER             = 1005; # >
-    const T_ECHO                = 1006; # >>>
-    const T_GREATER_OR_EQUAL    = 1007; # >=
-    const T_BITWISE_SHIFT_RIGHT = 1008; # >>>
-
-    # :
-    const T_COLON               = 1009; # :
-    const T_ASSIGN              = 1010; # :-
-
-    # -
-    const T_PLUS                = 1011; # +
-    const T_CONCAT_LIST         = 1012; # +++
-    const T_CONCAT              = 1013; # ++
-
-    # *
-    const T_STAR                = 1014; # *
-    const T_POW                 = 1015; # **
-
-    # =
-    const T_EQUAL               = 1016; # =
-    const T_REGEX_EQUAL         = 1017; # =~
-
-    # |
-    const T_BITWISE_OR          = 1018; # |
-    const T_PIPELINE            = 1019; # |>
-
-    # ^
-    const T_CIRCUNFLEX          = 1020; # ^
-    const T_CLONE               = 1021; # ^^
-
-    # &
-    const T_BITWISE_AND         = 1022; # &
-    const T_PARAMETERLESS_FN    = 1023; # &{ expr }
-    const T_PARTIAL_FN          = 1024; # &( op expr )
-
-    # .
-    const T_DOT                 = 1025; # .
-    const T_ELLIPSIS            = 1026; # ...
-
-    # ?
-    const T_SIMPLE_IF           = 1027; # ?
-    const T_SIMPLE_TERNARY      = 1028; # ?:
-    const T_NULL_COALESCENCE    = 1029; # ??
-
-    # Single char operators
-    const T_NEW                 = 1030; # #
-    const T_AT                  = 1031; # @
-    const T_BANG                = 1032; # !
-    const T_MINUS               = 1033; # -
-    const T_BITWISE_NOT         = 1034; # ~
-
-    public static function getPunctuator($code)
-    {
-        $op_table = static::getOpTable();
-
-        if (in_array($code, $op_table, true)) {
-            if (is_string($code)) {
-                return $code;
-            }
-
-            switch ($code) {
-                case Tag::T_AND:
-                    return 'and';
-                case Tag::T_OR:
-                    return 'or';
-                case Tag::T_XOR:
-                    return 'xor';
-                case Tag::T_NOT:
-                    return 'not';
-                case Tag::T_MOD:
-                    return 'mod';
-            }
-        }
-
-        return null;
-    }
-
-    // TODO: Separate operators that can be used as the start of an expression
-    // from the others
-    public static function getOpTable()
-    {
-        return [
-            Tag::T_LESSER              => '<',
-            Tag::T_RETURN              => '^',
-            Tag::T_BITWISE_SHIFT_LEFT  => '<<',
-            Tag::T_DIFFERENT           => '<>',
-            Tag::T_LESSER_OR_EQUAL     => '<=',
-            Tag::T_GREATER             => '>',
-            Tag::T_ECHO                => '>>>',
-            Tag::T_GREATER_OR_EQUAL    => '>=',
-            Tag::T_BITWISE_SHIFT_RIGHT => '>>',
-            Tag::T_COLON               => ':',
-            Tag::T_ASSIGN              => ':-',
-            Tag::T_PLUS                => '+',
-            Tag::T_CONCAT_LIST         => '+++',
-            Tag::T_CONCAT              => '++',
-            Tag::T_STAR                => '*',
-            Tag::T_POW                 => '**',
-            Tag::T_EQUAL               => '=',
-            Tag::T_REGEX_EQUAL         => '=~',
-            Tag::T_BITWISE_OR          => '|',
-            Tag::T_PIPELINE            => '|>',
-            Tag::T_CIRCUNFLEX          => '^',
-            Tag::T_CLONE               => '^^',
-            Tag::T_BITWISE_AND         => '&',
-            Tag::T_PARAMETERLESS_FN    => '&{',
-            Tag::T_PARTIAL_FN          => '&(',
-            Tag::T_DOT                 => '.',
-            Tag::T_ELLIPSIS            => '...',
-            Tag::T_SIMPLE_IF           => '?',
-            Tag::T_SIMPLE_TERNARY      => '?:',
-            Tag::T_NULL_COALESCENCE    => '??',
-            Tag::T_NEW                 => 'new',
-            Tag::T_AT                  => '@',
-            Tag::T_BANG                => '!',
-            Tag::T_MINUS               => '-',
-            Tag::T_BITWISE_NOT         => '~',
-            Tag::T_NEW                 => '#',
-            Tag::T_AND                 => Tag::T_AND,
-            Tag::T_OR                  => Tag::T_OR,
-            Tag::T_XOR                 => Tag::T_XOR,
-            Tag::T_NOT                 => Tag::T_NOT,
-            Tag::T_MOD                 => Tag::T_MOD
+    public static function & getPartialOperators() {
+        static $op_table = [
+            // Arithmetic
+            '+', '-', '*', '/', '**', Tag::T_MOD,
+            // Boolean algebra
+            Tag::T_NOT, Tag::T_AND, Tag::T_OR,
+            // Comparison
+            '<', '>', '<=', '>=', '=', '<>', '=~',
+            // Bitwise operations
+            '<<', '>>', '~', '|', '&',
+            // Others
+            '|>', ':-', '.', '?.', '??', '+++', '++'
         ];
+
+        return $op_table;
     }
 
     public static function getName($x)

--- a/src/parser/Grammar.php
+++ b/src/parser/Grammar.php
@@ -285,7 +285,7 @@ class Grammar
     public function _breakStmt()
     {
         $this->parser->match(Tag::T_BREAK);
-        $expression = $this->_optExpr();;
+        $expression = $this->_optExpr();
         return new BreakStmt($expression);
     }
 

--- a/src/parser/Parser.php
+++ b/src/parser/Parser.php
@@ -178,13 +178,6 @@ abstract class Parser
         return $this->lookahead->getTag() === $tag;
     }
 
-    public function isOperator()
-    {
-        $op = $this->lookahead->getTag();
-        $op_table = array_values(Tag::getOpTable());
-        return in_array($op, $op_table, true);
-    }
-
     public function consume()
     {
         $pointer = $this->lookahead === null ?: $this->lookahead->getPointer();

--- a/src/parser/TokenChecker.php
+++ b/src/parser/TokenChecker.php
@@ -52,41 +52,32 @@ class TokenChecker
 
     public function startsStmt()
     {
-        return $this->parser->is(Tag::T_IF)       // Done
-            || $this->parser->is(Tag::T_LET)      // Done
-            || $this->parser->is(Tag::T_WHILE)    // Done
-            || $this->parser->is(Tag::T_DO)       // Done
-            || $this->parser->is(Tag::T_FOR)      // Done
-            || $this->parser->is(Tag::T_FOREACH)  // Done
-            || $this->parser->is(Tag::T_SWITCH)   // Done
-            || $this->parser->is(Tag::T_TRY)      // Done
-            || $this->parser->is(Tag::T_BREAK)    // Done
-            || $this->parser->is(Tag::T_CONTINUE) // Done
-            || $this->parser->is(Tag::T_GOTO)     // Done
-            || $this->parser->is(Tag::T_GLOBAL)   // Done
-            || $this->parser->is(Tag::T_RAISE)    // Done
-            || $this->parser->is(Tag::T_BEGIN)    // Done
-            || $this->parser->is('^')             // Done
-            || $this->parser->is(':-');           // Done
-    }
+        static $possible_stmts = [
+            Tag::T_IF,
+            Tag::T_LET,
+            Tag::T_WHILE,
+            Tag::T_DO,
+            Tag::T_FOR,
+            Tag::T_FOREACH,
+            Tag::T_SWITCH,
+            Tag::T_TRY,
+            Tag::T_BREAK,
+            Tag::T_CONTINUE,
+            Tag::T_GOTO,
+            Tag::T_GLOBAL,
+            Tag::T_RAISE,
+            Tag::T_BEGIN,
+            '^',
+            ':-'
+        ];
 
-    public function startsExpr()
-    {
-        return $this->parser->is(Tag::T_INTEGER)
-            || $this->parser->is(Tag::T_DOUBLE)
-            || $this->parser->is(Tag::T_FN)
-            || $this->parser->is(Tag::T_REQUIRE)
-            || $this->parser->is(Tag::T_INCLUDE)
-            || $this->parser->is(Tag::T_IDENT)
-            || $this->parser->is(Tag::T_TRUE)
-            || $this->parser->is(Tag::T_FALSE)
-            || $this->parser->is(Tag::T_NIL)
-            || $this->parser->is(Tag::T_WHEN)
-            || $this->parser->is(Tag::T_STRING)
-            || $this->parser->is(Tag::T_ATOM)
-            || $this->parser->isOperator()
-            || $this->parser->is('{')
-            || $this->parser->is('(');
+        foreach ($possible_stmts as $token) {
+            if ($this->parser->is($token)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function startsClassDeclStmt()


### PR DESCRIPTION
This improves performance and reduces complexibility. It also fixes the common problem of static operators. Quack is mutable. You'll define operators in compile time, and I'm making this part of the compiler supportive to this.
