### PR TITLE
Partial functions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -23,9 +23,12 @@
 - [x] Verify associative array definitions
 - [x] Implement short syntax for `open` statements
 - [x] Make print an expression and stdout an alias for echo
-- [ ] Implement partial function parsing
+- [x] Implement partial function parsing
 - [ ] Implement static properties (without semantic validation)
 - [ ] Verify property definitions for classes
 - [ ] Implement trait support
 - [ ] Fix line-0-bug
 - [ ] Better syntax error output
+- [ ] Implement where-clause
+- [ ] Make do-notation accept multiple expressions
+- [ ] Make function-def be a statement. Fix parsing

--- a/src/ast/expr/PartialFuncExpr.php
+++ b/src/ast/expr/PartialFuncExpr.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Quack Compiler and toolkit
+ * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
+ * CONTRIBUTORS.
+ *
+ * This file is part of Quack.
+ *
+ * Quack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Quack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Quack.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace QuackCompiler\Ast\Expr;
+
+use \QuackCompiler\Lexer\Tag;
+use \QuackCompiler\Parser\Parser;
+
+class PartialFuncExpr implements Expr
+{
+    public $operator;
+    public $right;
+
+    public function __construct($operator, $right = null)
+    {
+        $this->operator = $operator;
+        $this->right = $right;
+    }
+
+    public function format(Parser $parser)
+    {
+        throw new \Exception('TODO');
+    }
+}

--- a/src/lexer/Tag.php
+++ b/src/lexer/Tag.php
@@ -91,16 +91,33 @@ class Tag
 
     public static function & getPartialOperators() {
         static $op_table = [
-            // Arithmetic
-            '+', '-', '*', '/', '**', Tag::T_MOD,
-            // Boolean algebra
-            Tag::T_NOT, Tag::T_AND, Tag::T_OR,
-            // Comparison
-            '<', '>', '<=', '>=', '=', '<>', '=~',
-            // Bitwise operations
-            '<<', '>>', '~', '|', '&',
-            // Others
-            '|>', ':-', '.', '?.', '??', '+++', '++'
+            '+',
+            '-',
+            '*',
+            '/',
+            '**',
+            Tag::T_MOD,
+            Tag::T_NOT,
+            Tag::T_AND,
+            Tag::T_OR,
+            '<',
+            '>',
+            '<=',
+            '>=',
+            '=',
+            '<>',
+            '=~',
+            '<<',
+            '>>',
+            '~',
+            '|',
+            '&',
+            '|>',
+            '.',
+            '?.',
+            '??',
+            '+++',
+            '++',
         ];
 
         return $op_table;

--- a/src/parselets/PartialFuncParselet.php
+++ b/src/parselets/PartialFuncParselet.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Quack Compiler and toolkit
+ * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
+ * CONTRIBUTORS.
+ *
+ * This file is part of Quack.
+ *
+ * Quack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Quack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Quack.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace QuackCompiler\Parselets;
+
+use \QuackCompiler\Ast\Expr\PartialFuncExpr;
+use \QuackCompiler\Lexer\Tag;
+use \QuackCompiler\Lexer\Token;
+use \QuackCompiler\Parser\Grammar;
+
+class PartialFuncParselet implements IPrefixParselet
+{
+    public function parse(Grammar $grammar, Token $token)
+    {
+        $op_table = &Tag::getPartialOperators();
+        $next_op = $grammar->parser->lookahead->getTag();
+        $right = null;
+
+        if (in_array($next_op, $op_table, true)) {
+            $grammar->parser->match($next_op);
+
+            // Faster than _optExpr
+            if (!$grammar->parser->is(')')) {
+                $right = $grammar->_expr();
+            }
+
+            $grammar->parser->match(')');
+        } else {
+            $grammar->parser->match('operator');
+        }
+
+        return new PartialFuncExpr($next_op, $right);
+    }
+}

--- a/src/parser/Grammar.php
+++ b/src/parser/Grammar.php
@@ -654,9 +654,9 @@ class Grammar
                     -> found($token)
                     -> on($this->parser->position())
                     -> source($this->parser->input);
-            } else {
-                return null;
             }
+
+            return null;
         }
 
         $left = $prefix->parse($this, $token);

--- a/src/parser/Parser.php
+++ b/src/parser/Parser.php
@@ -43,6 +43,7 @@ use \QuackCompiler\Parselets\WhenParselet;
 use \QuackCompiler\Parselets\CallParselet;
 use \QuackCompiler\Parselets\AccessParselet;
 use \QuackCompiler\Parselets\RangeParselet;
+use \QuackCompiler\Parselets\PartialFuncParselet;
 
 abstract class Parser
 {
@@ -91,6 +92,7 @@ abstract class Parser
 
     private function registerParselets()
     {
+        $this->register('&(', new PartialFuncParselet);
         $this->register(Tag::T_INTEGER, new LiteralParselet);
         $this->register(Tag::T_DOUBLE, new LiteralParselet);
         $this->register(Tag::T_STRING, new LiteralParselet);

--- a/src/toolkit/QuackToolkit.php
+++ b/src/toolkit/QuackToolkit.php
@@ -66,6 +66,7 @@ import(PARSELETS, 'CallParselet');
 import(PARSELETS, 'AccessParselet');
 import(PARSELETS, 'RangeParselet');
 import(PARSELETS, 'LiteralParselet');
+import(PARSELETS, 'PartialFuncParselet');
 
 /* Ast */
 
@@ -92,6 +93,7 @@ import(AST, 'expr/CallExpr');
 import(AST, 'expr/AccessExpr');
 import(AST, 'expr/RangeExpr');
 import(AST, 'expr/AtomExpr');
+import(AST, 'expr/PartialFuncExpr');
 
 import(AST, 'stmt/Stmt');
 import(AST, 'stmt/BlockStmt');


### PR DESCRIPTION
## Intro

This pull-request implements partial functions with operators on Quack compiler.

In Quack, operators are more than just operators. They are functions, and they can be partialized. Quack will use the syntax `&( <op> [ <expr> ] )` for them.
## Examples

``` ocaml
(* Store function in a variable *)
let add :- &(+)
do print[ add[ 10; 20 ] ] (* 30 *)

(* IIFE *)
do &(+ 10)[ 20 ] (* 30 *)

(* Store a function that pipes a div function *)
let pipe :- &(|> array_map[ &(/ 2) ])
do pipe[ { 10; 20; 30 } ] (* 5, 10, 15 *)

(* Sum to itself *)
do &(+ &0)[ 10 ] (* 20 *)

(* Divide each of the list by 2 *)
do array_map[ &(/ 2);  { 10; 20; 30 } ] (* 5; 10; 15 *)
```

:rainbow: :rainbow: :rainbow: 
