### PR TITLE
Make do-expr support multiple expressions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,11 +24,11 @@
 - [x] Implement short syntax for `open` statements
 - [x] Make print an expression and stdout an alias for echo
 - [x] Implement partial function parsing
+- [x] Make do-notation accept multiple expressions
 - [ ] Implement static properties (without semantic validation)
 - [ ] Verify property definitions for classes
 - [ ] Implement trait support
 - [ ] Fix line-0-bug
 - [ ] Better syntax error output
 - [ ] Implement where-clause
-- [ ] Make do-notation accept multiple expressions
 - [ ] Make function-def be a statement. Fix parsing

--- a/src/parser/Grammar.php
+++ b/src/parser/Grammar.php
@@ -181,8 +181,15 @@ class Grammar
     public function _exprStmt()
     {
         $this->parser->match(Tag::T_DO);
-        $expr = $this->_expr();
-        return new ExprStmt($expr);
+
+        $expr_list = [$this->_expr()];
+
+        while ($this->parser->is(',')) {
+            $this->parser->consume();
+            $expr_list[] = $this->_expr();
+        }
+
+        return new ExprStmt($expr_list);
     }
 
     public function _blockStmt()


### PR DESCRIPTION
This pull-request makes the `do` notation support multiple expressions.
### Before

``` erlang
do print[ "Hello World!" ]
do some_list |> array_map[ &(* 2 ) ] |> array_walk[ print ]
do 0xAEF + 0b10101001 << 0x01 |> strval |> print
```
### Now

``` erlang
do print[ "Hello World!" ],
   some_list |> array_map[ &(* 2 ) ] |> array_walk[ print ],
   0xAEF + 0b10101001 << 0x01 |> strval |> print
```
