### PR TITLE
Make [let] support multiple definitions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -25,6 +25,7 @@
 - [x] Make print an expression and stdout an alias for echo
 - [x] Implement partial function parsing
 - [x] Make do-notation accept multiple expressions
+- [x] Make let-notation accept multiple definitions
 - [ ] Implement static properties (without semantic validation)
 - [ ] Verify property definitions for classes
 - [ ] Implement trait support

--- a/src/ast/stmt/LetStmt.php
+++ b/src/ast/stmt/LetStmt.php
@@ -25,13 +25,11 @@ use \QuackCompiler\Parser\Parser;
 
 class LetStmt implements Stmt
 {
-    public $name;
-    public $value;
+    public $definitions;
 
-    public function __construct($name, $value)
+    public function __construct($definitions = [])
     {
-        $this->name = $name;
-        $this->value = $value;
+        $this->definitions = $definitions;
     }
 
     public function format(Parser $parser)

--- a/src/parser/Grammar.php
+++ b/src/parser/Grammar.php
@@ -216,11 +216,24 @@ class Grammar
     public function _letStmt()
     {
         $this->parser->match(Tag::T_LET);
+        $definitions = [];
+
+        // First definition is required (without comma)
+        // I could just use a goto, but, Satan would want my soul...
         $name = $this->identifier();
         $this->parser->match(':-');
         $value = $this->_expr();
+        $definitions[$name] = $value;
 
-        return new LetStmt($name, $value);
+        if ($this->parser->is(',')) {
+            $this->parser->consume();
+            $name = $this->identifier();
+            $this->parser->match(':-');
+            $value = $this->_expr();
+            $definitions[$name] = $value;
+        }
+
+        return new LetStmt($definitions);
     }
 
     public function _whileStmt()


### PR DESCRIPTION
This pull-request implements support in `let` statement for multiple expressions.
### Before

``` sml
let x :- 1
let y :- 2
let somebody_to_love :- nil (* :( *)
let add_10 :- &(+ 10)
```
### Now

``` sml
let x :- 1, y :- 2, somebody_to_love :- nil, add_10 :- &(+ 10)
```
##### Or

``` sml
let x :- 1,
    y :- 2,
    somebody_to_love :- nil,
    add_10 :- &(+ 10)
```
