### PR TITLE
Implement support for where-clause

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -26,11 +26,11 @@
 - [x] Implement partial function parsing
 - [x] Make do-notation accept multiple expressions
 - [x] Make let-notation accept multiple definitions
+- [x] Implement where-clause
 - [ ] Implement static properties (without semantic validation)
 - [ ] Verify property definitions for classes
 - [ ] Implement trait support
 - [ ] Fix line-0-bug
 - [ ] Better syntax error output
-- [ ] Implement where-clause
 - [ ] Make function-def be a statement. Fix parsing
 - [ ] Implement built-in support for regexes

--- a/src/parser/Grammar.php
+++ b/src/parser/Grammar.php
@@ -681,6 +681,11 @@ class Grammar
 
         $left = $prefix->parse($this, $token);
 
+        // Where clause
+        if ($this->parser->is(Tag::T_WHERE)) {
+            $this->appendWhere($left);
+        }
+
         while ($precedence < $this->getPrecedence()) {
             $token = $this->parser->consumeAndFetch();
             $infix = $this->parser->infixParseletForToken($token);
@@ -699,6 +704,29 @@ class Grammar
     }
 
     /* Coproductions */
+    public function appendWhere(&$expr)
+    {
+        $this->parser->match(Tag::T_WHERE);
+        $where = [];
+
+        $name = $this->identifier();
+        $this->parser->match(':-');
+        $value = $this->_expr();
+        $where[$name] = $value;
+
+        while ($this->parser->is(',')) {
+            $this->parser->consume();
+            $name = $this->identifier();
+            $this->parser->match(':-');
+            $value = $this->_expr();
+            $where[$name] = $value;
+        }
+
+        $this->parser->match(Tag::T_END);
+
+        $expr->where = $where;
+    }
+
     public function qualifiedName()
     {
         $symbol_pointers = [$this->parser->match(Tag::T_IDENT)];


### PR DESCRIPTION
This pull-request implements support for the `where` clause in expressions.
Its grammar may be defined by:

``` pascal
where-expr ::= <expr> where <ident> :- <expr> { , <ident> :- <expr> } end
```
### Examples

``` erlang
do print[ "Hello " ++ name ] where
  name :- "Marcelo"
end

let simple_computation :- x + y + z where
  x :- 0xAEFF,
  y :- 0b1010101,
  c :- 037177
end
```
