### PR TITLE
Class-based programming

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,8 +28,8 @@
 - [x] Make let-notation accept multiple definitions
 - [x] Implement where-clause
 - [x] Make function-def be a statement. Fix parsing
+- [x] Verify property definitions for classes
 - [ ] Implement static properties (without semantic validation)
-- [ ] Verify property definitions for classes
 - [ ] Implement trait support
 - [ ] Fix line-0-bug
 - [ ] Better syntax error output

--- a/src/ast/stmt/BlueprintStmt.php
+++ b/src/ast/stmt/BlueprintStmt.php
@@ -23,7 +23,7 @@ namespace QuackCompiler\Ast\Stmt;
 
 use \QuackCompiler\Parser\Parser;
 
-class ClassStmt implements Stmt
+class BlueprintStmt implements Stmt
 {
     public $name;
     public $extends;

--- a/src/ast/stmt/ConstStmt.php
+++ b/src/ast/stmt/ConstStmt.php
@@ -25,21 +25,15 @@ use \QuackCompiler\Parser\Parser;
 
 class ConstStmt implements Stmt
 {
-    public $name;
-    public $value;
+    public $definitions;
 
-    public function __construct($name, $value)
+    public function __construct($definitions)
     {
-        $this->name = $name;
-        $this->value = $value;
+        $this->definitions = $definitions;
     }
 
     public function format(Parser $parser)
     {
-        $string_builder = ['const '];
-        $string_builder[] = $this->name;
-        $string_builder[] = ' :- ';
-        $string_builder[] = $this->value->format($parser);
-        return implode($string_builder);
+        throw new \Exception;
     }
 }

--- a/src/ast/stmt/FnStmt.php
+++ b/src/ast/stmt/FnStmt.php
@@ -29,43 +29,17 @@ class FnStmt implements Stmt
     public $by_reference;
     public $body;
     public $parameters;
-    public $modifiers = [];
 
-    public function __construct($name, $by_reference, $body, $parameters, $modifiers = [])
+    public function __construct($name, $by_reference, $body, $parameters)
     {
         $this->name = $name;
         $this->by_reference = $by_reference;
         $this->body = $body;
         $this->parameters = $parameters;
-        $this->modifiers = $modifiers;
     }
 
     public function format(Parser $parser)
     {
-        $string_builder = ['fn '];
-        if ($this->by_reference) {
-            $string_builder[] = '*';
-        }
-
-        $string_builder[] = $this->name;
-        if (sizeof($this->parameters) > 0) {
-            $string_builder[] = ' [';
-
-            for ($i = 0, $l = sizeof($this->parameters); $i < $l; $i++) {
-                $string_builder[] = $this->parameters[$i]->format($parser);
-
-                if ($i !== $l - 1) {
-                    $string_builder[] = ', ';
-                }
-            }
-
-            $string_builder[] = '] ';
-        } else {
-            $string_builder[] = '! ';
-        }
-
-        $string_builder[] = $this->body->format($parser);
-
-        return implode($string_builder);
+        throw new \Exception;
     }
 }

--- a/src/ast/stmt/MemberStmt.php
+++ b/src/ast/stmt/MemberStmt.php
@@ -23,21 +23,17 @@ namespace QuackCompiler\Ast\Stmt;
 
 use \QuackCompiler\Parser\Parser;
 
-class PropertyStmt implements Stmt
+class MemberStmt implements Stmt
 {
-    public $name;
-    public $value;
-    public $modifiers;
+    public $definitions;
 
-    public function __construct($name, $value, $modifiers = [])
+    public function __construct($definitions)
     {
-        $this->name = $name;
-        $this->value = $value;
-        $this->modifiers = $modifiers;
+        $this->definitions = $definitions;
     }
 
     public function format(Parser $parser)
     {
-        throw new TodoException;
+        throw new \Exception;
     }
 }

--- a/src/lexer/Lexer.php
+++ b/src/lexer/Lexer.php
@@ -98,6 +98,7 @@ abstract class Lexer
         $this->reserve(new Word(Tag::T_BY, "by"));
         $this->reserve(new Word(Tag::T_WHEN, "when"));
         $this->reserve(new Word(Tag::T_UNLESS, "unless"));
+        $this->reserve(new Word(Tag::T_MEMBER, "member"));
     }
 
     private function reserve(Word $t)

--- a/src/lexer/Lexer.php
+++ b/src/lexer/Lexer.php
@@ -58,7 +58,7 @@ abstract class Lexer
         $this->reserve(new Word(Tag::T_INIT, "init"));
         $this->reserve(new Word(Tag::T_SELF, "self"));
         $this->reserve(new Word(Tag::T_MODULE, "module"));
-        $this->reserve(new Word(Tag::T_CLASS, "class"));
+        $this->reserve(new Word(Tag::T_BLUEPRINT, "blueprint"));
         $this->reserve(new Word(Tag::T_GOTO, "goto"));
         $this->reserve(new Word(Tag::T_FOREACH, "foreach"));
         $this->reserve(new Word(Tag::T_IN, "in"));

--- a/src/lexer/Tag.php
+++ b/src/lexer/Tag.php
@@ -45,7 +45,7 @@ class Tag
     const T_INIT = 267;
     const T_SELF = 268;
     const T_MODULE = 269;
-    const T_CLASS = 270;
+    const T_BLUEPRINT = 270;
     const T_NIL = 272;
     const T_LET = 273;
     const T_CONST = 274;

--- a/src/lexer/Tag.php
+++ b/src/lexer/Tag.php
@@ -87,6 +87,7 @@ class Tag
     const T_BY = 305;
     const T_WHEN = 306;
     const T_UNLESS = 307;
+    const T_MEMBER = 308;
 
     public static function & getPartialOperators() {
         static $op_table = [

--- a/src/parser/Grammar.php
+++ b/src/parser/Grammar.php
@@ -395,21 +395,17 @@ class Grammar
 
     public function _innerStmt()
     {
-        if ($this->checker->startsStmt()) {
-            return $this->_stmt();
-        }
+        $branch_table = [
+            Tag::T_FN        => '_fnStmt',
+            Tag::T_BLUEPRINT => '_blueprintStmt',
+            Tag::T_STRUCT    => '_structDeclStmt'
+        ];
 
-        if ($this->parser->is(Tag::T_FN)) {
-            return $this->_fnStmt();
-        }
+        $next_tag = $this->parser->lookahead->getTag();
 
-        if ($this->checker->is(Tag::T_BLUEPRINT)) {
-            return $this->_blueprintDeclStmt();
-        }
-
-        if ($this->parser->is(Tag::T_STRUCT)) {
-            return $this->_structDeclStmt();
-        }
+        return array_key_exists($next_tag, $branch_table)
+            ? call_user_func([$this, $branch_table[$next_tag]])
+            : $this->_stmt();
     }
 
     public function _blueprintStmt()

--- a/src/parser/Grammar.php
+++ b/src/parser/Grammar.php
@@ -29,7 +29,7 @@ use \QuackCompiler\Ast\Expr\ArrayPairExpr;
 use \QuackCompiler\Ast\Stmt\BlockStmt;
 use \QuackCompiler\Ast\Stmt\BreakStmt;
 use \QuackCompiler\Ast\Stmt\CaseStmt;
-use \QuackCompiler\Ast\Stmt\ClassStmt;
+use \QuackCompiler\Ast\Stmt\BlueprintStmt;
 use \QuackCompiler\Ast\Stmt\ConstStmt;
 use \QuackCompiler\Ast\Stmt\ContinueStmt;
 use \QuackCompiler\Ast\Stmt\FnStmt;
@@ -99,7 +99,7 @@ class Grammar
         }
     }
 
-    public function _classStmtList()
+    public function _blueprintStmtList()
     {
         while (!$this->checker->isEoF()) {
             switch ($this->parser->lookahead->getTag()) {
@@ -107,7 +107,7 @@ class Grammar
                 case Tag::T_CONST:
                 case Tag::T_OPEN:
                 case Tag::T_MEMBER:
-                    yield $this->_classStmt();
+                    yield $this->_blueprintStmt();
                     continue 2;
                 default:
                     break 2;
@@ -389,8 +389,8 @@ class Grammar
             return $this->_stmt();
         }
 
-        if ($this->checker->startsClassDeclStmt()) {
-            return $this->_classDeclStmt();
+        if ($this->parser->is(Tag::T_BLUEPRINT)) {
+            return $this->_blueprintDeclStmt();
         }
 
         if ($this->parser->is(Tag::T_STRUCT)) {
@@ -424,8 +424,8 @@ class Grammar
             return $this->_fnStmt();
         }
 
-        if ($this->checker->startsClassDeclStmt()) {
-            return $this->_classDeclStmt();
+        if ($this->checker->is(Tag::T_BLUEPRINT)) {
+            return $this->_blueprintDeclStmt();
         }
 
         if ($this->parser->is(Tag::T_STRUCT)) {
@@ -433,7 +433,7 @@ class Grammar
         }
     }
 
-    public function _classStmt()
+    public function _blueprintStmt()
     {
         $branch_table = [
             Tag::T_OPEN   => '_openStmt',
@@ -479,13 +479,13 @@ class Grammar
         return new MemberStmt($definitions);
     }
 
-    public function _classDeclStmt()
+    public function _blueprintDeclStmt()
     {
         $extends = null;
         $implements = [];
 
-        $this->parser->match(Tag::T_CLASS);
-        $class_name = $this->identifier();
+        $this->parser->match(Tag::T_BLUEPRINT);
+        $blueprint_name = $this->identifier();
 
         if ($this->parser->is(':')) {
             $this->parser->consume();
@@ -499,10 +499,10 @@ class Grammar
             } while ($this->parser->is(';'));
         }
 
-        $body = iterator_to_array($this->_classStmtList());
+        $body = iterator_to_array($this->_blueprintStmtList());
         $this->parser->match(Tag::T_END);
 
-        return new ClassStmt($class_name, $extends, $implements, $body);
+        return new BlueprintStmt($blueprint_name, $extends, $implements, $body);
     }
 
     public function _structDeclStmt()
@@ -518,7 +518,7 @@ class Grammar
             } while ($this->parser->is(';'));
         }
 
-        $body = iterator_to_array($this->_classStmtList());
+        $body = iterator_to_array($this->_blueprintStmtList());
         $this->parser->match(Tag::T_END);
         $name = $this->identifier();
 

--- a/src/parser/Grammar.php
+++ b/src/parser/Grammar.php
@@ -629,7 +629,9 @@ class Grammar
 
     public function _caseStmtList()
     {
-        while ($this->checker->startsCase()) {
+        $cases = [Tag::T_CASE, Tag::T_ELSE];
+
+        while (in_array($this->parser->lookahead->getTag(), $cases, true)) {
             $is_else = $this->parser->is(Tag::T_ELSE);
             $this->parser->consume();
             $value = $is_else ? null : $this->_expr();

--- a/src/parser/TokenChecker.php
+++ b/src/parser/TokenChecker.php
@@ -32,17 +32,6 @@ class TokenChecker
         $this->parser = $parser;
     }
 
-    public function startsTopStmt()
-    {
-        return $this->startsStmt()
-            || $this->parser->is(Tag::T_BLUEPRINT)
-            || $this->parser->is(Tag::T_STRUCT)
-            || $this->parser->is(Tag::T_FN)
-            || $this->parser->is(Tag::T_MODULE)
-            || $this->parser->is(Tag::T_OPEN)
-            || $this->parser->is(Tag::T_CONST);
-    }
-
     public function startsInnerStmt()
     {
         return $this->startsStmt()

--- a/src/parser/TokenChecker.php
+++ b/src/parser/TokenChecker.php
@@ -34,10 +34,14 @@ class TokenChecker
 
     public function startsInnerStmt()
     {
-        return $this->startsStmt()
-            || $this->parser->is(Tag::T_BLUEPRINT)
-            || $this->parser->is(Tag::T_STRUCT)
-            || $this->parser->is(Tag::T_FN);
+        $possible_inner_stmts = [
+            Tag::T_BLUEPRINT,
+            Tag::T_STRUCT,
+            Tag::T_FN
+        ];
+
+        return in_array($this->parser->lookahead->getTag(), $possible_inner_stmts, true)
+            || $this->startsStmt();
     }
 
     public function startsStmt()
@@ -61,13 +65,8 @@ class TokenChecker
             ':-'
         ];
 
-        foreach ($possible_stmts as $token) {
-            if ($this->parser->is($token)) {
-                return true;
-            }
-        }
-
-        return false;
+        $next_tag = $this->parser->lookahead->getTag();
+        return in_array($next_tag, $possible_stmts, true);
     }
 
     public function isEoF()

--- a/src/parser/TokenChecker.php
+++ b/src/parser/TokenChecker.php
@@ -91,14 +91,6 @@ class TokenChecker
             || $this->parser->is(Tag::T_ELSE);
     }
 
-    public function startsClassStmt()
-    {
-        return $this->parser->is(Tag::T_FN)
-            || $this->parser->is(Tag::T_CONST)
-            || $this->parser->is(Tag::T_OPEN)
-            || $this->parser->is(Tag::T_IDENT);
-    }
-
     public function isEoF()
     {
         return $this->parser->lookahead->getTag() === 0;

--- a/src/parser/TokenChecker.php
+++ b/src/parser/TokenChecker.php
@@ -70,12 +70,6 @@ class TokenChecker
         return false;
     }
 
-    public function startsCase()
-    {
-        return $this->parser->is(Tag::T_CASE)
-            || $this->parser->is(Tag::T_ELSE);
-    }
-
     public function isEoF()
     {
         return $this->parser->lookahead->getTag() === 0;

--- a/src/parser/TokenChecker.php
+++ b/src/parser/TokenChecker.php
@@ -35,7 +35,7 @@ class TokenChecker
     public function startsTopStmt()
     {
         return $this->startsStmt()
-            || $this->startsClassDeclStmt()
+            || $this->parser->is(Tag::T_BLUEPRINT)
             || $this->parser->is(Tag::T_STRUCT)
             || $this->parser->is(Tag::T_FN)
             || $this->parser->is(Tag::T_MODULE)
@@ -46,8 +46,9 @@ class TokenChecker
     public function startsInnerStmt()
     {
         return $this->startsStmt()
-            || $this->parser->is(Tag::T_FN)
-            || $this->startsClassDeclStmt();
+            || $this->parser->is(Tag::T_BLUEPRINT)
+            || $this->parser->is(Tag::T_STRUCT)
+            || $this->parser->is(Tag::T_FN);
     }
 
     public function startsStmt()
@@ -78,11 +79,6 @@ class TokenChecker
         }
 
         return false;
-    }
-
-    public function startsClassDeclStmt()
-    {
-        return $this->parser->is(Tag::T_CLASS);
     }
 
     public function startsCase()

--- a/src/toolkit/QuackToolkit.php
+++ b/src/toolkit/QuackToolkit.php
@@ -118,7 +118,7 @@ import(AST, 'stmt/ModuleStmt');
 import(AST, 'stmt/OpenStmt');
 import(AST, 'stmt/PieceStmt');
 import(AST, 'stmt/PrintStmt');
-import(AST, 'stmt/PropertyStmt');
+import(AST, 'stmt/MemberStmt');
 import(AST, 'stmt/RaiseStmt');
 import(AST, 'stmt/RescueStmt');
 import(AST, 'stmt/ReturnStmt');

--- a/src/toolkit/QuackToolkit.php
+++ b/src/toolkit/QuackToolkit.php
@@ -99,7 +99,7 @@ import(AST, 'stmt/Stmt');
 import(AST, 'stmt/BlockStmt');
 import(AST, 'stmt/BreakStmt');
 import(AST, 'stmt/CaseStmt');
-import(AST, 'stmt/ClassStmt');
+import(AST, 'stmt/BlueprintStmt');
 import(AST, 'stmt/ConstStmt');
 import(AST, 'stmt/ContinueStmt');
 import(AST, 'stmt/FnStmt');

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -108,7 +108,7 @@ class LexerTest extends \PHPUnit_Framework_TestCase
     {
         $keywords = [
             "true", "false", "let", "if", "for", "while", "do", "struct",
-            "init", "self", "module", "class", "goto", "foreach", "in", "where",
+            "init", "self", "module", "goto", "foreach", "in", "where",
             "const", "nil", "open", "global", "as", "enum", "continue", "switch",
             "break", "and", "or", "xor", "try", "rescue", "finally", "raise", "elif",
             "else", "case", "super", "is", "not"
@@ -116,7 +116,7 @@ class LexerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             "[true][false][let][if][for][while][do][struct]" .
-            "[init][self][module][class][goto][foreach][in][where][const][nil]" .
+            "[init][self][module][goto][foreach][in][where][const][nil]" .
             "[open][global][as][enum][continue][switch][break][and][or][xor][try]" .
             "[rescue][finally][raise][elif][else][case][super][is]" .
             "[not]",


### PR DESCRIPTION
This pull-request implements the basis and aims to define the behavior of class-based-programming on Quack compiler. We need to discuss before merging it.

Currently, the following approach is implemented in this PR:
- There are no interfaces. Classes implement protocols (that variables may also do)
- There are no `final` nor `abstract` classes. Abstraction is defined by the type system and we must discuss if `final` should be implemented
- Properties are defined with the keyword `member`
- Private items are named by a preceding `_`
### Current definition example

``` ocaml
class Tuple
  member a; b
  init[ %self a; %self b ] end (* %self makes a direct member attribution *)
  fn fst! ^ self.a end
  fn snd! ^ self.b end
end

let pair :- #Tuple { 1, 2 }
do print[ pair.fst! ]
```

I'm also proposing operator overloading:

``` sml
class Tuple
  [... stuff ...]
  operator (+)[other]
    #Tuple { self.a + other.a; self.b + other.b }
  end
end

let pair1 :- #Tuple { 1; 2 }
let pair2 :- #Tuple { 3; 4 }
do var_dump[ pair1 + pair2 ] (* (4; 6) *)
```
### Votes
- [ ] Implement final classes
- [ ] Use explicit visibility modifiers
- [ ] Implement support for trait injection
- [ ] Operator overloading for class
- [ ] Multiple inheritance
- [ ] Partial classes

Please, if you want to vote (or discuss), comment what you believe is good to be implemented in the section `votes` and what not (and why).

Note that we want to keep Quack grammar as simple and extensible as possible. Avoid reserving keywords. Also remember that Quack doesn't target _only_ PHP, but a set of languages and VMs.
### My votes
- [ ] Implement final classes
- [ ] Use explicit visibility modifiers
- [x] Implement support for trait injection
- [x] Operator overloading for class
- [ ] Multiple inheritance
- [x] Partial classes
