### PR TITLE
Regex

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -33,6 +33,6 @@
 - [x] Better syntax error output
 - [x] Fix column count on string
 - [x] Ignore comments
+- [x] Implement built-in support for regexes
 - [ ] Implement static properties (without semantic validation)
 - [ ] Implement trait support
-- [ ] Implement built-in support for regexes

--- a/src/ast/expr/RegexExpr.php
+++ b/src/ast/expr/RegexExpr.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Quack Compiler and toolkit
+ * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
+ * CONTRIBUTORS.
+ *
+ * This file is part of Quack.
+ *
+ * Quack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Quack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Quack.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace QuackCompiler\Ast\Expr;
+
+use \QuackCompiler\Parser\Parser;
+
+class RegexExpr implements Expr
+{
+    public $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    public function format(Parser $parser)
+    {
+        return '/' . $this->value . '/';
+    }
+}

--- a/src/ast/expr/RegexExpr.php
+++ b/src/ast/expr/RegexExpr.php
@@ -34,6 +34,6 @@ class RegexExpr implements Expr
 
     public function format(Parser $parser)
     {
-        return '/' . $this->value . '/';
+        return $this->value;
     }
 }

--- a/src/lexer/Tag.php
+++ b/src/lexer/Tag.php
@@ -32,6 +32,7 @@ class Tag
     const T_STRING = 600;
     const T_ATOM = 601;
     const T_PARAM = 1000;
+    const T_REGEX = 1001;
 
     /* Keywords */
     const T_TRUE = 260;

--- a/src/lexer/Tokenizer.php
+++ b/src/lexer/Tokenizer.php
@@ -215,7 +215,6 @@ class Tokenizer extends Lexer
         $buffer[] = $this->readChar();
         $this->column++;
 
-
         while (!$this->isEnd() && !($this->is('/') && $this->previous() !== '\\')) {
             $buffer[] = $this->readChar();
             $this->column++;

--- a/src/lexer/Tokenizer.php
+++ b/src/lexer/Tokenizer.php
@@ -211,22 +211,32 @@ class Tokenizer extends Lexer
 
     private function regex()
     {
-        $this->consume();
+        $buffer = [];
+        $buffer[] = $this->readChar();
         $this->column++;
 
-        $buffer = [];
 
         while (!$this->isEnd() && !($this->is('/') && $this->previous() !== '\\')) {
             $buffer[] = $this->readChar();
             $this->column++;
         }
 
-        $regex = implode($buffer);
-
         if (!$this->isEnd()) {
-            $this->consume();
+            $buffer[] = $this->readChar();
             $this->column++;
+
+            // Regex modifiers
+            $allowed_modifiers = [
+                'i', 'm', 's', 'x', 'e', 'A', 'D', 'S', 'U', 'X', 'J', 'u'
+            ];
+
+            while (in_array($this->peek, $allowed_modifiers, true)) {
+                $buffer[] = $this->readChar();
+                $this->column++;
+            }
         }
+
+        $regex = implode($buffer);
 
         return new Token(Tag::T_REGEX, $this->symbol_table->add($regex));
     }

--- a/src/lexer/Tokenizer.php
+++ b/src/lexer/Tokenizer.php
@@ -216,7 +216,7 @@ class Tokenizer extends Lexer
 
         $buffer = [];
 
-        while (!$this->isEnd() && !$this->is('/')) {
+        while (!$this->isEnd() && !($this->is('/') && $this->previous() !== '\\')) {
             $buffer[] = $this->readChar();
             $this->column++;
         }

--- a/src/lexer/Tokenizer.php
+++ b/src/lexer/Tokenizer.php
@@ -63,6 +63,10 @@ class Tokenizer extends Lexer
                 return $this->string($this->peek);
             }
 
+            if ($this->is('/')) {
+                return $this->regex();
+            }
+
             // Multichar symbol analysis
             return SymbolDecypher::{$this->peek}($this);
         }
@@ -203,6 +207,28 @@ class Tokenizer extends Lexer
         }
 
         return new Token(Tag::T_STRING, $this->symbol_table->add($string));
+    }
+
+    private function regex()
+    {
+        $this->consume();
+        $this->column++;
+
+        $buffer = [];
+
+        while (!$this->isEnd() && !$this->is('/')) {
+            $buffer[] = $this->readChar();
+            $this->column++;
+        }
+
+        $regex = implode($buffer);
+
+        if (!$this->isEnd()) {
+            $this->consume();
+            $this->column++;
+        }
+
+        return new Token(Tag::T_REGEX, $this->symbol_table->add($regex));
     }
 
     private function comment()

--- a/src/parselets/LiteralParselet.php
+++ b/src/parselets/LiteralParselet.php
@@ -26,6 +26,7 @@ use \QuackCompiler\Ast\Expr\StringExpr;
 use \QuackCompiler\Ast\Expr\AtomExpr;
 use \QuackCompiler\Ast\Expr\NilExpr;
 use \QuackCompiler\Ast\Expr\BoolExpr;
+use \QuackCompiler\Ast\Expr\RegexExpr;
 use \QuackCompiler\Lexer\Tag;
 use \QuackCompiler\Lexer\Token;
 use \QuackCompiler\Parser\Grammar;
@@ -56,6 +57,9 @@ class LiteralParselet implements IPrefixParselet
             case Tag::T_TRUE:
             case Tag::T_FALSE:
                 return new BoolExpr($tag === Tag::T_TRUE);
+
+            case Tag::T_REGEX:
+                return new RegexExpr($grammar->parser->resolveScope($token->getPointer()));
         }
     }
 }

--- a/src/parser/Parser.php
+++ b/src/parser/Parser.php
@@ -96,6 +96,7 @@ abstract class Parser
         $this->register(Tag::T_INTEGER, new LiteralParselet);
         $this->register(Tag::T_DOUBLE, new LiteralParselet);
         $this->register(Tag::T_STRING, new LiteralParselet);
+        $this->register(Tag::T_REGEX, new LiteralParselet);
         $this->register(Tag::T_IDENT, new NameParselet);
         $this->register(Tag::T_THEN, new TernaryParselet);
         $this->register('..', new RangeParselet);
@@ -140,6 +141,7 @@ abstract class Parser
         $this->infixLeft('<<', Precedence::BITWISE_SHIFT);
         $this->infixLeft('>>', Precedence::BITWISE_SHIFT);
         $this->infixLeft('=', Precedence::VALUE_COMPARATOR);
+        $this->infixLeft('=~', Precedence::VALUE_COMPARATOR);
         $this->infixLeft('<>', Precedence::VALUE_COMPARATOR);
         $this->infixLeft('<=', Precedence::SIZE_COMPARATOR);
         $this->infixLeft('<', Precedence::SIZE_COMPARATOR);

--- a/src/parser/SyntaxError.php
+++ b/src/parser/SyntaxError.php
@@ -126,7 +126,7 @@ class SyntaxError extends Exception
         $found_tag = $this->found->getTag();
 
         // String literals have quotes also!
-        if ($found_tag === Tag::T_STRING) {
+        if (in_array($found_tag, [Tag::T_REGEX, Tag::T_STRING], true)) {
             $offset += 2;
         }
 

--- a/src/parser/SyntaxError.php
+++ b/src/parser/SyntaxError.php
@@ -126,7 +126,7 @@ class SyntaxError extends Exception
         $found_tag = $this->found->getTag();
 
         // String literals have quotes also!
-        if (in_array($found_tag, [Tag::T_REGEX, Tag::T_STRING], true)) {
+        if (Tag::T_STRING === $found_tag) {
             $offset += 2;
         }
 

--- a/src/toolkit/QuackToolkit.php
+++ b/src/toolkit/QuackToolkit.php
@@ -94,6 +94,7 @@ import(AST, 'expr/AccessExpr');
 import(AST, 'expr/RangeExpr');
 import(AST, 'expr/AtomExpr');
 import(AST, 'expr/PartialFuncExpr');
+import(AST, 'expr/RegexExpr');
 
 import(AST, 'stmt/Stmt');
 import(AST, 'stmt/BlockStmt');


### PR DESCRIPTION
This pull-request implements built-in support for regular expressions and the `=~` operator

``` ruby
if "haskell" =~ /[a-z]/i
  do write[ "It matches!" ]
end
```

It accepts the pattern modifiers from PCRE and escaped characters.
