### PR TITLE
Words self and super are not reserved

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -34,6 +34,7 @@
 - [x] Fix column count on string
 - [x] Ignore comments
 - [x] Implement built-in support for regexes
+- [x] Support for `super` and `self` call
 - [ ] Implement static properties (without semantic validation)
 - [ ] Implement trait support
-- [ ] Support for `super` call
+- [ ] Implement enum

--- a/TODO.md
+++ b/TODO.md
@@ -33,6 +33,7 @@
 - [x] Better syntax error output
 - [x] Fix column count on string
 - [x] Ignore comments
+- [x] Implement built-in support for regexes
 - [ ] Implement static properties (without semantic validation)
 - [ ] Implement trait support
-- [ ] Implement built-in support for regexes
+- [ ] Support for `super` call

--- a/src/lexer/Lexer.php
+++ b/src/lexer/Lexer.php
@@ -56,7 +56,6 @@ abstract class Lexer
         $this->reserve(new Word(Tag::T_DO, "do"));
         $this->reserve(new Word(Tag::T_STRUCT, "struct"));
         $this->reserve(new Word(Tag::T_INIT, "init"));
-        $this->reserve(new Word(Tag::T_SELF, "self"));
         $this->reserve(new Word(Tag::T_MODULE, "module"));
         $this->reserve(new Word(Tag::T_BLUEPRINT, "blueprint"));
         $this->reserve(new Word(Tag::T_GOTO, "goto"));
@@ -83,8 +82,6 @@ abstract class Lexer
         $this->reserve(new Word(Tag::T_ELIF, "elif"));
         $this->reserve(new Word(Tag::T_ELSE, "else"));
         $this->reserve(new Word(Tag::T_CASE, "case"));
-        $this->reserve(new Word(Tag::T_SUPER, "super"));
-        $this->reserve(new Word(Tag::T_IS, "is"));
         $this->reserve(new Word(Tag::T_NOT, "not"));
         $this->reserve(new Word(Tag::T_FN, "fn"));
         $this->reserve(new Word(Tag::T_REQUIRE, "require"));

--- a/src/lexer/Tag.php
+++ b/src/lexer/Tag.php
@@ -43,7 +43,6 @@ class Tag
     const T_DO = 265;
     const T_STRUCT = 266;
     const T_INIT = 267;
-    const T_SELF = 268;
     const T_MODULE = 269;
     const T_BLUEPRINT = 270;
     const T_NIL = 272;
@@ -71,8 +70,6 @@ class Tag
     const T_ELIF = 520;
     const T_ELSE = 521;
     const T_CASE = 522;
-    const T_SUPER = 525;
-    const T_IS = 527;
     const T_MOD = 292;
     const T_NOT = 293;
     const T_FN = 294;

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -89,18 +89,17 @@ class LexerTest extends \PHPUnit_Framework_TestCase
     {
         $keywords = [
             "true", "false", "let", "if", "for", "while", "do", "struct",
-            "init", "self", "module", "goto", "foreach", "in", "where",
+            "init", "module", "goto", "foreach", "in", "where",
             "const", "nil", "open", "global", "as", "enum", "continue", "switch",
             "break", "and", "or", "xor", "try", "rescue", "finally", "raise", "elif",
-            "else", "case", "super", "is", "not"
+            "else", "case", "not"
         ];
 
         $this->assertEquals(
             "[true][false][let][if][for][while][do][struct]" .
-            "[init][self][module][goto][foreach][in][where][const][nil]" .
+            "[init][module][goto][foreach][in][where][const][nil]" .
             "[open][global][as][enum][continue][switch][break][and][or][xor][try]" .
-            "[rescue][finally][raise][elif][else][case][super][is]" .
-            "[not]",
+            "[rescue][finally][raise][elif][else][case][not]",
             $this->tokenize(implode(' ', $keywords))
         );
     }


### PR DESCRIPTION
The words `self` and `super` are **semantic** and context-variant. We shouldn't reserve them, but look into the `lexeme` when inside a blueprint.
