### PR TITLE
Enum support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
 *.qk linguist-language=OCaml
 *.qkt linguist-language=OCaml
-*.php linguist-language=Hack
 *.qtest linguist-language=Hy

--- a/TODO.md
+++ b/TODO.md
@@ -35,6 +35,6 @@
 - [x] Ignore comments
 - [x] Implement built-in support for regexes
 - [x] Support for `super` and `self` call
+- [x] Implement enum
 - [ ] Implement static properties (without semantic validation)
 - [ ] Implement trait support
-- [ ] Implement enum

--- a/src/ast/stmt/EnumStmt.php
+++ b/src/ast/stmt/EnumStmt.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Quack Compiler and toolkit
+ * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
+ * CONTRIBUTORS.
+ *
+ * This file is part of Quack.
+ *
+ * Quack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Quack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Quack.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace QuackCompiler\Ast\Stmt;
+
+use \QuackCompiler\Parser\Parser;
+
+class EnumStmt implements Stmt
+{
+    public $entries;
+    public $name;
+
+    public function __construct($name, $entries)
+    {
+        $this->name = $name;
+        $this->entries = $entries;
+    }
+
+    public function format(Parser $parser)
+    {
+        throw new \Exception;
+    }
+}

--- a/src/parser/Grammar.php
+++ b/src/parser/Grammar.php
@@ -35,6 +35,7 @@ use \QuackCompiler\Ast\Stmt\ContinueStmt;
 use \QuackCompiler\Ast\Stmt\FnStmt;
 use \QuackCompiler\Ast\Stmt\DoWhileStmt;
 use \QuackCompiler\Ast\Stmt\ElifStmt;
+use \QuackCompiler\Ast\Stmt\EnumStmt;
 use \QuackCompiler\Ast\Stmt\ExprStmt;
 use \QuackCompiler\Ast\Stmt\ForeachStmt;
 use \QuackCompiler\Ast\Stmt\ForStmt;
@@ -383,7 +384,8 @@ class Grammar
             Tag::T_FN        => '_fnStmt',
             Tag::T_MODULE    => '_moduleStmt',
             Tag::T_OPEN      => '_openStmt',
-            Tag::T_CONST     => '_constStmt'
+            Tag::T_CONST     => '_constStmt',
+            Tag::T_ENUM      => '_enumStmt'
         ];
 
         $next_tag = $this->parser->lookahead->getTag();
@@ -397,8 +399,9 @@ class Grammar
     {
         $branch_table = [
             Tag::T_FN        => '_fnStmt',
-            Tag::T_BLUEPRINT => '_blueprintStmt',
-            Tag::T_STRUCT    => '_structDeclStmt'
+            Tag::T_BLUEPRINT => '_blueprintDeclStmt',
+            Tag::T_STRUCT    => '_structDeclStmt',
+            Tag::T_ENUM      => '_enumStmt'
         ];
 
         $next_tag = $this->parser->lookahead->getTag();
@@ -452,6 +455,21 @@ class Grammar
         }
 
         return new MemberStmt($definitions);
+    }
+
+    public function _enumStmt()
+    {
+        $this->parser->match(Tag::T_ENUM);
+        $entries = [];
+        $name = $this->identifier();
+
+        while ($this->parser->is(Tag::T_IDENT)) {
+            $entries[] = $this->identifier();
+        }
+
+        $this->parser->match(Tag::T_END);
+
+        return new EnumStmt($entries);
     }
 
     public function _blueprintDeclStmt()

--- a/src/parser/TokenChecker.php
+++ b/src/parser/TokenChecker.php
@@ -37,7 +37,8 @@ class TokenChecker
         $possible_inner_stmts = [
             Tag::T_BLUEPRINT,
             Tag::T_STRUCT,
-            Tag::T_FN
+            Tag::T_FN,
+            Tag::T_ENUM
         ];
 
         return in_array($this->parser->lookahead->getTag(), $possible_inner_stmts, true)

--- a/src/toolkit/QuackToolkit.php
+++ b/src/toolkit/QuackToolkit.php
@@ -107,6 +107,7 @@ import(AST, 'stmt/FnStmt');
 import(AST, 'stmt/ForStmt');
 import(AST, 'stmt/DoWhileStmt');
 import(AST, 'stmt/ElifStmt');
+import(AST, 'stmt/EnumStmt');
 import(AST, 'stmt/ExprStmt');
 import(AST, 'stmt/ForeachStmt');
 import(AST, 'stmt/GlobalStmt');


### PR DESCRIPTION
This pull-request adds support for enums on Quack Compiler.

``` erlang
enum Fruits
  Apple
  Orange
  Banana
end
```

Enums can also be used at bit level, as flags

``` fsharp
let fruits :- Fruits.Apple + Fruits.Orange + Fruits.Banana

if fruits & Fruits.Apple
  do print[ "I see you like apples" ]
end
```
