### PR TITLE
Use const for immutable variables

### DIFF
--- a/src/parser/Grammar.php
+++ b/src/parser/Grammar.php
@@ -134,6 +134,7 @@ class Grammar
         $branch_table = [
             Tag::T_IF       => '_ifStmt',
             Tag::T_LET      => '_letStmt',
+            Tag::T_CONST    => '_constStmt',
             Tag::T_WHILE    => '_whileStmt',
             Tag::T_DO       => '_exprStmt',
             Tag::T_FOR      => '_forStmt',
@@ -384,7 +385,6 @@ class Grammar
             Tag::T_FN        => '_fnStmt',
             Tag::T_MODULE    => '_moduleStmt',
             Tag::T_OPEN      => '_openStmt',
-            Tag::T_CONST     => '_constStmt',
             Tag::T_ENUM      => '_enumStmt'
         ];
 
@@ -416,7 +416,6 @@ class Grammar
         $branch_table = [
             Tag::T_OPEN   => '_openStmt',
             Tag::T_FN     => '_fnStmt',
-            Tag::T_CONST  => '_constStmt',
             Tag::T_MEMBER => '_memberStmt'
         ];
 


### PR DESCRIPTION
This pull-request implements the use of the `const` keyword for immutable variables:

``` js
let name :- "Marcelo"
do name :- "Haskell" (* pass *)

const favorite_animal :- "Capybara"
do favorite_animal :- "Dog" (* error *)
```
