### PR TITLE
Extensions on Quack

### DIFF
--- a/src/ast/stmt/ExtensionStmt.php
+++ b/src/ast/stmt/ExtensionStmt.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Quack Compiler and toolkit
+ * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
+ * CONTRIBUTORS.
+ *
+ * This file is part of Quack.
+ *
+ * Quack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Quack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Quack.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace QuackCompiler\Ast\Stmt;
+
+use \QuackCompiler\Parser\Parser;
+
+class ExtensionStmt implements Stmt
+{
+    public $appliesTo;
+    public $implements;
+    public $body;
+
+    public function __construct($appliesTo, $implements, $body)
+    {
+        $this->appliesTo = $appliesTo;
+        $this->implements = $implements;
+        $this->body = $body;
+    }
+
+    public function format(Parser $parser)
+    {
+        throw new \Exception('TODO');
+    }
+}

--- a/src/ast/stmt/ExtensionStmt.php
+++ b/src/ast/stmt/ExtensionStmt.php
@@ -26,12 +26,14 @@ use \QuackCompiler\Parser\Parser;
 class ExtensionStmt implements Stmt
 {
     public $appliesTo;
+    public $appliesToRegexes;
     public $implements;
     public $body;
 
-    public function __construct($appliesTo, $implements, $body)
+    public function __construct($appliesTo, $appliesToRegexes, $implements, $body)
     {
         $this->appliesTo = $appliesTo;
+        $this->appliesToRegexes = $appliesToRegexes;
         $this->implements = $implements;
         $this->body = $body;
     }

--- a/src/lexer/Lexer.php
+++ b/src/lexer/Lexer.php
@@ -58,6 +58,7 @@ abstract class Lexer
         $this->reserve(new Word(Tag::T_INIT, "init"));
         $this->reserve(new Word(Tag::T_MODULE, "module"));
         $this->reserve(new Word(Tag::T_BLUEPRINT, "blueprint"));
+        $this->reserve(new Word(Tag::T_EXTENSION, "extension"));
         $this->reserve(new Word(Tag::T_GOTO, "goto"));
         $this->reserve(new Word(Tag::T_FOREACH, "foreach"));
         $this->reserve(new Word(Tag::T_IN, "in"));

--- a/src/lexer/Tag.php
+++ b/src/lexer/Tag.php
@@ -45,6 +45,7 @@ class Tag
     const T_INIT = 267;
     const T_MODULE = 269;
     const T_BLUEPRINT = 270;
+    const T_EXTENSION = 271;
     const T_NIL = 272;
     const T_LET = 273;
     const T_CONST = 274;
@@ -62,7 +63,6 @@ class Tag
     const T_AND = 511;
     const T_OR = 512;
     const T_XOR = 513;
-    const T_EXTENSION = 800;
     const T_TRY = 515;
     const T_RESCUE = 516;
     const T_FINALLY = 517;
@@ -86,7 +86,8 @@ class Tag
     const T_UNLESS = 307;
     const T_MEMBER = 308;
 
-    public static function & getPartialOperators() {
+    public static function & getPartialOperators()
+    {
         static $op_table = [
             '+',
             '-',

--- a/src/parser/Grammar.php
+++ b/src/parser/Grammar.php
@@ -475,19 +475,26 @@ class Grammar
 
     public function _extensionDeclStmt()
     {
-        $appliesTo = null;
+        $appliesTo = [];
+        $appliesToRegexes = [];
         $implements = [];
 
         $this->parser->match(Tag::T_EXTENSION);
-        if ($this->parser->is(Tag::T_FOR)) {
-            $this->parser->consume();
+        $this->parser->match(Tag::T_FOR);
 
+        do {
             if ($this->parser->is(Tag::T_REGEX)) {
-                $appliesTo = $this->parser->consumeAndFetch();
+                $appliesToRegexes[] = $this->parser->consumeAndFetch();
             } else {
-                $appliesTo = $this->qualifiedName();
+                $appliesTo[] = $this->qualifiedName();
             }
-        }
+
+            if ($this->parser->is(';')) {
+                $this->parser->consume();
+            } else {
+                break;
+            }
+        } while (true);
 
         if ($this->parser->is('#')) {
             do {
@@ -499,7 +506,7 @@ class Grammar
         $body = iterator_to_array($this->_blueprintStmtList());
         $this->parser->match(Tag::T_END);
 
-        return new ExtensionStmt($appliesTo, $implements, $body);
+        return new ExtensionStmt($appliesTo, $appliesToRegexes, $implements, $body);
     }
 
     public function _blueprintDeclStmt()

--- a/src/parser/Grammar.php
+++ b/src/parser/Grammar.php
@@ -30,6 +30,7 @@ use \QuackCompiler\Ast\Stmt\BlockStmt;
 use \QuackCompiler\Ast\Stmt\BreakStmt;
 use \QuackCompiler\Ast\Stmt\CaseStmt;
 use \QuackCompiler\Ast\Stmt\BlueprintStmt;
+use \QuackCompiler\Ast\Stmt\ExtensionStmt;
 use \QuackCompiler\Ast\Stmt\ConstStmt;
 use \QuackCompiler\Ast\Stmt\ContinueStmt;
 use \QuackCompiler\Ast\Stmt\FnStmt;
@@ -385,7 +386,8 @@ class Grammar
             Tag::T_FN        => '_fnStmt',
             Tag::T_MODULE    => '_moduleStmt',
             Tag::T_OPEN      => '_openStmt',
-            Tag::T_ENUM      => '_enumStmt'
+            Tag::T_ENUM      => '_enumStmt',
+            Tag::T_EXTENSION => '_extensionDeclStmt'
         ];
 
         $next_tag = $this->parser->lookahead->getTag();
@@ -469,6 +471,35 @@ class Grammar
         $this->parser->match(Tag::T_END);
 
         return new EnumStmt($entries);
+    }
+
+    public function _extensionDeclStmt()
+    {
+        $appliesTo = null;
+        $implements = [];
+
+        $this->parser->match(Tag::T_EXTENSION);
+        if ($this->parser->is(Tag::T_FOR)) {
+            $this->parser->consume();
+
+            if ($this->parser->is(Tag::T_REGEX)) {
+                $appliesTo = $this->parser->consumeAndFetch();
+            } else {
+                $appliesTo = $this->qualifiedName();
+            }
+        }
+
+        if ($this->parser->is('#')) {
+            do {
+                $this->parser->consume();
+                $implements[] = $this->qualifiedName();
+            } while ($this->parser->is(';'));
+        }
+
+        $body = iterator_to_array($this->_blueprintStmtList());
+        $this->parser->match(Tag::T_END);
+
+        return new ExtensionStmt($appliesTo, $implements, $body);
     }
 
     public function _blueprintDeclStmt()

--- a/src/toolkit/QuackToolkit.php
+++ b/src/toolkit/QuackToolkit.php
@@ -101,6 +101,7 @@ import(AST, 'stmt/BlockStmt');
 import(AST, 'stmt/BreakStmt');
 import(AST, 'stmt/CaseStmt');
 import(AST, 'stmt/BlueprintStmt');
+import(AST, 'stmt/ExtensionStmt');
 import(AST, 'stmt/ConstStmt');
 import(AST, 'stmt/ContinueStmt');
 import(AST, 'stmt/FnStmt');

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -92,14 +92,14 @@ class LexerTest extends \PHPUnit_Framework_TestCase
             "init", "module", "goto", "foreach", "in", "where",
             "const", "nil", "open", "global", "as", "enum", "continue", "switch",
             "break", "and", "or", "xor", "try", "rescue", "finally", "raise", "elif",
-            "else", "case", "not"
+            "else", "case", "not", "blueprint", "extension"
         ];
 
         $this->assertEquals(
             "[true][false][let][if][for][while][do][struct]" .
             "[init][module][goto][foreach][in][where][const][nil]" .
             "[open][global][as][enum][continue][switch][break][and][or][xor][try]" .
-            "[rescue][finally][raise][elif][else][case][not]",
+            "[rescue][finally][raise][elif][else][case][not][blueprint][extension]",
             $this->tokenize(implode(' ', $keywords))
         );
     }


### PR DESCRIPTION
This pull request aims to implement `extensions` on Quack.
Before merging, please check if the approach is good enough. I'm doing it based on [this](https://github.com/quack/quack/pull/45). _// implementation of partial classes using extensions_

While in that comment we were thinking of something like that,

``` Swift
extension to_string for * : T {
  ^ strval[ <T> self ]
}
```

this PR has a new approach over the language and represents a new feature.
- [x] Definition example #1 _extensions are simple_

``` Swift
extension for House
   member nRooms ; nBathrooms 
   fn rooms! ^ self.nRooms end 
end
```
- [x] Definition example #2 _extensions might implement protocols_

``` Swift
extension for String # UTF8Encoding ; Base64
   ...
end
```
- [x] Definition example #3 _extensions can be applied for multiple statements_

``` Swift
extension for String ; Int # Base64
   ...
end
```
- [x] Definition example #4 _extensions might use Regexes and other statements all together :D_

``` Swift
// gets any file that finishes with "Controller" and the String blueprint, implements the DataProtocol
extension for /\w*Controller/g ;  String # DataProtocol
   ...
end
```

How is it?
