### PR TITLE
added qtest file for extensions

### DIFF
--- a/src/ast/stmt/ExtensionStmt.php
+++ b/src/ast/stmt/ExtensionStmt.php
@@ -40,6 +40,29 @@ class ExtensionStmt implements Stmt
 
     public function format(Parser $parser)
     {
-        throw new \Exception('TODO');
+        $source = 'extension for ';
+
+        $source .= implode('; ', array_map(function ($param) {
+            return implode('', $param);
+        }, $this->appliesTo));
+
+        $source .= implode('; ', array_map(function ($param) {
+            return $param->format($parser);
+        }, $this->appliesToRegexes));
+
+        if (count($this->implements) > 0) {
+            $source .= ' # ';
+            $source .= implode('; ', array_map(function ($param) {
+                return implode('', $param);
+            }, $this->implements));
+        }
+
+        foreach ($this->body as $node) {
+            $node->format($parser);
+        }
+
+        $source .= ' end'. PHP_EOL;
+
+        return $source;
     }
 }

--- a/src/ast/stmt/ExtensionStmt.php
+++ b/src/ast/stmt/ExtensionStmt.php
@@ -58,7 +58,7 @@ class ExtensionStmt implements Stmt
         }
 
         foreach ($this->body as $node) {
-            $node->format($parser);
+            $source .= $node->format($parser);
         }
 
         $source .= ' end'. PHP_EOL;

--- a/tests/stmt/extension_stmt.qtest
+++ b/tests/stmt/extension_stmt.qtest
@@ -1,0 +1,29 @@
+%%comments
+
+// The T_REGEX is not working properly.
+//TODO: Implement tests for T_REGEX.
+//TODO: Implement members, fns and more...
+
+// Examples below
+
+extension for    String#      UTF8Encoding ; Base64 member x end
+
+extension for House
+   member nRooms ; nBathrooms
+   fn rooms! ^ self.nRooms end
+end
+
+%%describe
+Supports formatting extensions
+%%source
+extension for    String#      UTF8Encoding ; Base64 end
+extension for House
+end
+
+extension for Igloo      ; Castle;    SpanishColonial
+
+end
+%%expect
+extension for String # UTF8Encoding; Base64 end
+extension for House end
+extension for Igloo; Castle; SpanishColonial end

--- a/tools/testsuite/run-tests.hy
+++ b/tools/testsuite/run-tests.hy
@@ -88,6 +88,8 @@
     ; Parser is cumulative. You can have multiple and isolated sections
     (for [line lines]
       (cond
+        [(= line "%%comments")
+          (setv tok :none)]
         [(= line "%%describe")
           (setv tok :describe)]
         [(= line "%%source")


### PR DESCRIPTION
This PR adds qtests for `extensions` and includes a new directive (`%%comments`), allowing the use of comments inside `qtests` files.
