### PR TITLE
Changing the regex from /regex/u to &/regex/u

### DIFF
--- a/src/lexer/Tokenizer.php
+++ b/src/lexer/Tokenizer.php
@@ -63,11 +63,8 @@ class Tokenizer extends Lexer
                 return $this->string($this->peek);
             }
 
-            if ($this->is('/')) {
-                $regex = $this->regex();
-                if ($regex) {
-                    return $regex;
-                }
+            if ($this->matches('&/')) {
+                return $this->regex();
             }
 
             // Multichar symbol analysis
@@ -217,25 +214,20 @@ class Tokenizer extends Lexer
 
     private function regex()
     {
-        $position = $this->position;
         $buffer = [];
         $buffer[] = $this->readChar();
-        $this->column++;
+        $buffer[] = $this->readChar();
+        $this->column += 2;
 
         while (!$this->isEnd() && !($this->is('/') && $this->previous() !== '\\')) {
             $buffer[] = $this->readChar();
             $this->column++;
         }
 
-        if ($this->peek != '/') {
-            $steps = $this->position - $position;
-            $this->column -= $steps;
-            $this->stepback($steps);
-            return NULL;
+        if (!$this->isEnd()) {
+            $buffer[] = $this->readChar();
+            $this->column++;
         }
-
-        $buffer[] = $this->readChar();
-        $this->column++;
 
         // Regex modifiers
         $allowed_modifiers = [


### PR DESCRIPTION
This PR is related to https://github.com/quack/quack/pull/63, https://github.com/quack/quack/pull/62 and https://github.com/quack/quack/pull/48

The `Lexer` was still having problems with disambiguations of codes like:

``` Rust
if str =~ /[a-zA-Z]?/u
    let x :- 2 + 3 / 4
    let y :- x / 4
end
```

In this case, that would take `/ 4 let y :- x /` as a regex (because that is seen as `if str =~ /[a-zA-Z]?/u let x :- 2 + 3 / 4 let y :- x / 4 end` by **Quack**), therefore, we changed our regexes patterns to `&/[a-zA-Z]?/u`.. in this way, the new code looks like:

``` Rust
if str =~ &/[a-zA-Z]?/u
    let x :- 2 + 3 / 4
    let y :- x / 4
end
```

And there are no ambiguations with that! yay :)
