### PR TITLE
Member access and object type inference

### DIFF
--- a/src/ast/expr/ObjectExpr.php
+++ b/src/ast/expr/ObjectExpr.php
@@ -22,6 +22,8 @@
 namespace QuackCompiler\Ast\Expr;
 
 use \QuackCompiler\Parser\Parser;
+use \QuackCompiler\Types\NativeQuackType;
+use \QuackCompiler\Types\Type;
 
 class ObjectExpr extends Expr
 {
@@ -73,5 +75,17 @@ class ObjectExpr extends Expr
         foreach ($this->values as $value) {
             $value->injectScope($parent_scope);
         }
+    }
+
+    public function getType()
+    {
+        $newtype = new Type(NativeQuackType::T_OBJ);
+        $newtype->props = [];
+
+        for ($i = 0, $size_t = sizeof($this->keys); $i < $size_t; $i++) {
+            $newtype->props[$this->keys[$i]] = $this->values[$i]->getType();
+        }
+
+        return $newtype;
     }
 }

--- a/src/ast/expr/OperatorExpr.php
+++ b/src/ast/expr/OperatorExpr.php
@@ -106,10 +106,21 @@ class OperatorExpr extends Expr
     {
         $type = (object)[
             'left'  => $this->left->getType(),
-            'right' => $this->right->getType()
+            'right' => 'string' === gettype($this->right) ? null : $this->right->getType()
         ];
 
         $op_name = Tag::getOperatorLexeme($this->operator);
+
+        $member_access = ['.', '?.'];
+        if (in_array($this->operator, $member_access, true)) {
+            if ('array' === gettype($type->left->props) && array_key_exists($this->right, $type->left->props)) {
+                return $type->left->props[$this->right];
+            }
+
+            throw new ScopeError([
+                'message' => "Expression of type `{$type->left}' has no property `{$this->right}'"
+            ]);
+        }
 
         // Type-checking for assignment. Don't worry. Left-hand assignment was handled on
         // scope injection

--- a/src/ast/expr/OperatorExpr.php
+++ b/src/ast/expr/OperatorExpr.php
@@ -111,6 +111,26 @@ class OperatorExpr extends Expr
 
         $op_name = Tag::getOperatorLexeme($this->operator);
 
+        // Type-checking for assignment. Don't worry. Left-hand assignment was handled on
+        // scope injection
+        if (':-' === $this->operator) {
+            // When right side cannot be attributed to left side
+            if (!$type->right->isCompatibleWith($type->left)) {
+                // TODO: Implement array destructuring in `let' expression
+                $target = (string) $type->right;
+
+                if ($this->left instanceof NameExpr) {
+                    $target = "variable `{$this->left->name}' :: {$type->left}";
+                }
+
+                throw new ScopeError([
+                    'message' => "Trying to set value of type `{$type->right}` to {$target}"
+                ]);
+            }
+
+            return Type::getBaseType([$type->left, $type->right]);
+        }
+
         // Type checking for numeric and string concat operations
         $numeric_op = ['+', '-', '*', '**', '/', '>>', '<<', '^', '&', '|', Tag::T_MOD];
         if (in_array($this->operator, $numeric_op, true)) {

--- a/src/ast/expr/PostfixExpr.php
+++ b/src/ast/expr/PostfixExpr.php
@@ -23,6 +23,8 @@ namespace QuackCompiler\Ast\Expr;
 
 use \QuackCompiler\Lexer\Tag;
 use \QuackCompiler\Parser\Parser;
+use \QuackCompiler\Types\NativeQuackType;
+use \QuackCompiler\Types\Type;
 
 class PostfixExpr extends Expr
 {
@@ -46,5 +48,12 @@ class PostfixExpr extends Expr
     public function injectScope(&$parent_scope)
     {
         $this->left->injectScope($parent_scope);
+    }
+
+    public function getType()
+    {
+        // TODO: Check implementations of postfix expressions.
+        // Currently, there is none
+        return new Type(NativeQuackType::T_LAZY);
     }
 }

--- a/src/types/Type.php
+++ b/src/types/Type.php
@@ -26,6 +26,7 @@ class Type
     public $code;
     public $subtype;
     public $supertype;
+    public $props; // For objects and multiple subtyping access
 
     public function __construct($code)
     {
@@ -57,6 +58,19 @@ class Type
                 return '?';
             case NativeQuackType::T_BLOCK:
                 return 'block';
+            case NativeQuackType::T_OBJ:
+                // TODO: Implement indent-level for types
+                $space = sizeof($this->props) > 0 ? " " : "";
+                $src = "object.of(?).with {{$space}";
+                foreach ($this->props as $key => $value) {
+                    $src .= "{$key} :: {$value}";
+                    // When is not the last one, append comma
+                    if ($key !== key(array_slice($this->props, -1, 1, true))) {
+                        $src .= ', ';
+                    }
+                }
+                $src .= "{$space}}";
+                return $src;
             default:
                 return 'unknown';
         }


### PR DESCRIPTION
This pull-request implements type inference for objects and type checking for member access on Quack compiler.

The operators `?.` and `.` are used to nullable and warranted member access. Objects may have subtyping and the comparison is structural. `?` represents anonymous objects and types. When used in an object with signature, we'll replace it by the nominal type, in order to specify type contracts.

![image](https://cloud.githubusercontent.com/assets/7553006/18153782/0fd04b1a-6fd6-11e6-8af9-5e3b1c871195.png)
