### PR TITLE
Type-checker on foreach

### DIFF
--- a/TYPECHECKER_TODO.md
+++ b/TYPECHECKER_TODO.md
@@ -12,7 +12,7 @@ Sprint 1:
 - [x] Impl with implicit `fn'
 - [x] Change syntax for comments
 - [x] Isolate declarations from simple statements
-- [ ] New syntax for lambda-expr
+- [x] New syntax for lambda-expr
 
 Sprint 2:
 
@@ -21,7 +21,6 @@ Sprint 2:
 - [ ] Run typechecker on ContinueStmt
 - [ ] Run typechecker on BreakStmt
 - [ ] Implement parser for type signatures
-- [ ] Create algorithm for covariance and contravariance
 - [ ] Implement sum-types and type combinators
 - [x] Run typechecker on SwitchStmt and CaseStmt // partially done: check TODO inside SwitchStmt.php
 - [ ] Run typechecker on ElifStmt

--- a/src/ast/stmt/BreakStmt.php
+++ b/src/ast/stmt/BreakStmt.php
@@ -73,4 +73,9 @@ class BreakStmt extends Stmt
             $parent_scope->setMeta('refcount', $this->label, $refcount + 1);
         }
     }
+
+    public function runTypeChecker()
+    {
+        // Pass
+    }
 }

--- a/src/ast/stmt/ContinueStmt.php
+++ b/src/ast/stmt/ContinueStmt.php
@@ -72,4 +72,9 @@ class ContinueStmt extends Stmt
             $parent_scope->setMeta('refcount', $this->label, $refcount + 1);
         }
     }
+
+    public function runTypeChecker()
+    {
+        // Pass
+    }
 }

--- a/src/ast/stmt/ForStmt.php
+++ b/src/ast/stmt/ForStmt.php
@@ -108,6 +108,7 @@ class ForStmt extends Stmt
             }
         }
 
+        // TODO: Remove covariance (at least for now)
         // Bind inferred type for variable
         $this->scope->setMeta('type', $this->variable, new Type(array_reduce($keys, function ($acc, $key) {
             return max($acc, $this->{$key}->getType()->code);

--- a/src/ast/stmt/ForeachStmt.php
+++ b/src/ast/stmt/ForeachStmt.php
@@ -127,10 +127,10 @@ class ForeachStmt extends Stmt
         }
 
         // When the element has no deducible subtype (map)
-        if (is_array($generator_type->subtype) && (in_array(NativeQuackType::T_LAZY, [
+        if (is_array($generator_type->subtype) && in_array(NativeQuackType::T_LAZY, [
             $generator_type->subtype['key']->code,
             $generator_type->subtype['value']->code
-        ], true))) {
+        ], true)) {
             throw new ScopeError([
                 'message' => "Undeducible `Map' subtype in `{$generator_type}'"
             ]);

--- a/src/ast/stmt/ForeachStmt.php
+++ b/src/ast/stmt/ForeachStmt.php
@@ -26,6 +26,7 @@ use \QuackCompiler\Parser\Parser;
 use \QuackCompiler\Scope\Kind;
 use \QuackCompiler\Scope\ScopeError;
 use \QuackCompiler\Types\NativeQuackType;
+use \QuackCompiler\Types\Type;
 
 class ForeachStmt extends Stmt
 {
@@ -106,8 +107,49 @@ class ForeachStmt extends Stmt
 
     public function runTypeChecker()
     {
-        // Currently, the rules are:
-        // Only first variable present: List | Map
-        // First and second variable presents: Map
+        // The following type-rules are applicable:
+        // List { key -> value } = ∀ a. List { Int -> a' }
+        // Map { key -> value } = ∀ a b. Map { a' -> b' }
+        $generator_type = $this->generator->getType();
+
+        // When the element has no subtype to be an iterable
+        if (null === $generator_type->subtype)  {
+            throw new ScopeError([
+                'message' => "`{$generator_type}' is not iterable"
+            ]);
+        }
+
+        // When the element has no deducible subtype (list)
+        if (!is_array($generator_type->subtype) && NativeQuackType::T_LAZY === $generator_type->subtype->code) {
+            throw new ScopeError([
+                'message' => "Undeducible subtype `{$generator_type->subtype}' of `{$generator_type}'"
+            ]);
+        }
+
+        // When the element has no deducible subtype (map)
+        if (is_array($generator_type->subtype) && (in_array(NativeQuackType::T_LAZY, [
+            $generator_type->subtype['key']->code,
+            $generator_type->subtype['value']->code
+        ], true))) {
+            throw new ScopeError([
+                'message' => "Undeducible `Map' subtype in `{$generator_type}'"
+            ]);
+        }
+
+        if (null !== $this->key) {
+            $this->scope->setMeta('type', $this->key, $generator_type->isList()
+                ? new Type(NativeQuackType::T_INT)
+                : clone $generator_type->subtype['key']
+            );
+        }
+
+        $this->scope->setMeta('type', $this->alias, $generator_type->isList()
+            ? clone $generator_type->subtype
+            : clone $generator_type->subtype['value']
+        );
+
+        foreach ($this->body as $stmt) {
+            $stmt->runTypeChecker();
+        }
     }
 }

--- a/src/lexer/Lexer.php
+++ b/src/lexer/Lexer.php
@@ -56,7 +56,6 @@ abstract class Lexer
         $this->reserve(new Word(Tag::T_WHILE, "while"));
         $this->reserve(new Word(Tag::T_DO, "do"));
         $this->reserve(new Word(Tag::T_MODULE, "module"));
-        $this->reserve(new Word(Tag::T_GOTO, "goto"));
         $this->reserve(new Word(Tag::T_FOREACH, "foreach"));
         $this->reserve(new Word(Tag::T_IN, "in"));
         $this->reserve(new Word(Tag::T_MOD, "mod"));

--- a/src/scope/Scope.php
+++ b/src/scope/Scope.php
@@ -66,7 +66,7 @@ class Scope
     {
         $scope = &$this->getSymbolScope($symbol);
 
-        if (!array_key_exists($symbol, $scope->meta)) {
+        if (null === $scope || !array_key_exists($symbol, $scope->meta)) {
             return null;
         }
 

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -80,7 +80,7 @@ class LexerTest extends \PHPUnit_Framework_TestCase
     {
         $keywords = [
             "true", "false", "let", "if", "for", "while", "do", "impl", "class", "shape",
-            "module", "goto", "foreach", "in", "where",
+            "module", "foreach", "in", "where",
             "const", "nil", "open", "global", "as", "enum", "continue", "switch",
             "break", "and", "or", "xor", "try", "rescue", "finally", "raise", "elif",
             "else", "case", "not"
@@ -88,7 +88,7 @@ class LexerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             "[true][false][let][if][for][while][do][impl][class][shape]" .
-            "[module][goto][foreach][in][where][const][nil]" .
+            "[module][foreach][in][where][const][nil]" .
             "[open][global][as][enum][continue][switch][break][and][or][xor][try]" .
             "[rescue][finally][raise][elif][else][case][not]",
             $this->tokenize(implode(' ', $keywords))


### PR DESCRIPTION
This pull-request implements type-checking/inference and injection on `foreach` statement. The inference is applicable for `List` and `Map` types, currently. It is based on the following rules:

```agda
List { key → value } ≃ ∀ a. List { Int → a' } → { Int → a' }
Map { key → value } ≃ ∀ a b. Map { a' → b' } → { a' → b' }
```

Therefore, thus, is provable that this code is valid and will not fall in invalid state during runtime:

```ruby
foreach i in { { 1; 2 }; { 3; 4 } }
  foreach j in i
    do j + 1
  end
end
```

When empty generators, such as `{}` or `${}` are set, the optimizer, after, will take care of removing them if not side-effects are found. The inference model of empty generators are:

```agda
Ø ≃ {}  × List.of(?)
  / ${} × Map.of(? → ?)
```
You'll get an error if you try to iter over an empty generator because the type can't be deduced.