### PR TITLE
Redefining numbers in Quack

### DIFF
--- a/src/ast/expr/NumberExpr.php
+++ b/src/ast/expr/NumberExpr.php
@@ -29,11 +29,13 @@ class NumberExpr extends Expr
 {
     public $value;
     public $type;
+    public $notation;
 
-    public function __construct($value, $type)
+    public function __construct($value, $type, $notation = 'decimal')
     {
         $this->value = $value;
         $this->type = $type;
+        $this->notation = $notation;
     }
 
     public function format(Parser $parser)

--- a/src/lexer/Tag.php
+++ b/src/lexer/Tag.php
@@ -26,9 +26,14 @@ use \ReflectionClass;
 class Tag
 {
     /* Constructions */
-    const T_IDENT = 257;
+
+    const T_IDENT = 253;
+    const T_INT_BIN = 255;
+    const T_INT_OCT = 256;
+    const T_INT_HEX = 257;
     const T_INTEGER = 258;
     const T_DOUBLE = 400;
+    const T_DOUBLE_EXP = 401;
     const T_STRING = 600;
     const T_ATOM = 601;
     const T_REGEX = 1001;

--- a/src/lexer/Tokenizer.php
+++ b/src/lexer/Tokenizer.php
@@ -84,6 +84,42 @@ class Tokenizer extends Lexer
         $buffer = [];
         $is_double = false;
 
+        $number = $this->readChar();
+        $this->column++;
+
+        // Check if it is binary, octal or hexadec
+        if ($number === '0' &&
+            (!((int) $this->preview() >> 1 && $this->peek === 'b' ||
+             !((int) $this->preview() >> 3 && $this->peek === 'o' ||
+             !((int) $this->preview() >> 4 && $this->peek === 'x' ))) {
+            $base = $this->readChar();
+            $this->column++;
+
+            switch ($base) {
+                case 'x':
+                    while (ctype_xdigit($this->peek)) {
+                        $buffer[] = $this->readChar();
+                    }
+                    
+                    break;
+
+                case 'o':
+                    while (ctype_digit($this->peek) && !((int) $this->peek >> 3)) {
+                        $buffer[] = $this->readChar();
+                    }
+                    break;
+                
+                case 'b':
+                    while (ctype_digit($this->peek) && !((int) $this->peek >> 1)) {
+                        $buffer[] = $this->readChar();
+                    }
+                    break;
+            }
+
+        } else if (in_array($this->peek, ['x', 'b', 'o']) {
+            return new Token(Tag::T_INTEGER, $this->symbol_table->add($number));
+        }
+
         // Hexadecimal or binary
         if ($this->peek === '0' && (in_array(strtolower($this->preview()), ['x', 'b']))) {
             $buffer[] = $this->readChar(); // 0

--- a/src/lexer/Tokenizer.php
+++ b/src/lexer/Tokenizer.php
@@ -143,12 +143,15 @@ class Tokenizer extends Lexer
             $buffer[] = $this->readChar(); // append '.'
             $buffer = array_merge($buffer, $this->integer());
         }
-        // check optional exp state: looking for a 'e+' or 'e-' and integers
-        if (!$this->isEnd() && ($this->matches('e+') || $this->matches('e-'))
-            && ctype_digit($this->preview(2))) {
+        // check optional exp state: looking for a 'e', 'e+' or 'e-' and integers
+        if (!$this->isEnd() && $this->is('e') && (
+            $this->preview() === '+' || $this->preview() === '-' ||
+            ctype_digit($this->preview()))) {
             $tag = Tag::T_DOUBLE_EXP;
             $buffer[] = $this->readChar(); // append 'e'
-            $buffer[] = $this->readChar(); // append '+' or '-'
+            if ($this->is('+') || $this->is('-')) {
+                $buffer[] = $this->readChar(); // append '+' or '-'
+            }
             $buffer = array_merge($buffer, $this->integer());
         }
 

--- a/src/lexer/Tokenizer.php
+++ b/src/lexer/Tokenizer.php
@@ -115,6 +115,12 @@ class Tokenizer extends Lexer
                             $buffer[] = $this->readChar();
                         } while (ctype_digit($this->peek) &&
                             !((int) $this->peek >> $bits));
+
+                        if (ctype_alpha(end($buffer))) {
+                            $found = false; // false positive:0b[2-9] or 0o[8-9]
+                            $buffer = []; // reset buffer
+                            $this->stepback(); // retract
+                        }
                     }
                 }
             }

--- a/src/parselets/LiteralParselet.php
+++ b/src/parselets/LiteralParselet.php
@@ -47,7 +47,9 @@ class LiteralParselet implements IPrefixParselet
 
             case Tag::T_DOUBLE:
             case Tag::T_INTEGER:
-                return new NumberExpr($grammar->parser->resolveScope($token->getPointer()));
+                return new NumberExpr($grammar->parser->resolveScope($token->getPointer()),
+                    $tag === Tag::T_DOUBLE ? 'double' : 'int'
+                );
 
             case Tag::T_INT_HEX:
                 return new NumberExpr(

--- a/src/parselets/LiteralParselet.php
+++ b/src/parselets/LiteralParselet.php
@@ -52,6 +52,26 @@ class LiteralParselet implements IPrefixParselet
                     $tag === Tag::T_DOUBLE ? 'double' : 'int'
                 );
 
+            case Tag::T_INT_HEX:
+                return new NumberExpr(
+                    $grammar->parser->resolveScope($token->getPointer()),
+                    'int', 'hexadec');
+
+            case Tag::T_INT_OCT:
+                return new NumberExpr(
+                    $grammar->parser->resolveScope($token->getPointer()),
+                    'int', 'octal');
+
+            case Tag::T_INT_BIN:
+                return new NumberExpr(
+                    $grammar->parser->resolveScope($token->getPointer()),
+                    'int', 'binary');
+
+            case Tag::T_DOUBLE_EXP:
+                return new NumberExpr(
+                    $grammar->parser->resolveScope($token->getPointer()),
+                    'double', 'scientific');
+
             case Tag::T_NIL:
                 return new NilExpr;
 

--- a/src/parser/Parser.php
+++ b/src/parser/Parser.php
@@ -97,7 +97,11 @@ abstract class Parser
     {
         $this->register('&(', new PartialFuncParselet);
         $this->register(Tag::T_INTEGER, new LiteralParselet);
+        $this->register(Tag::T_INT_HEX, new LiteralParselet);
+        $this->register(Tag::T_INT_OCT, new LiteralParselet);
+        $this->register(Tag::T_INT_BIN, new LiteralParselet);
         $this->register(Tag::T_DOUBLE, new LiteralParselet);
+        $this->register(Tag::T_DOUBLE_EXP, new LiteralParselet);
         $this->register(Tag::T_STRING, new LiteralParselet);
         $this->register(Tag::T_REGEX, new LiteralParselet);
         $this->register(Tag::T_IDENT, new NameParselet);

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -28,22 +28,28 @@ class LexerTest extends \PHPUnit_Framework_TestCase
     public function testNumber()
     {
         $decimal_integer = "1083";
-        $octal_integer = "0314";
-        $octal_partial_integer = "0314891";
+        $octal_integer = "0o314";
+        $octal_partial_integer = "0o314891";
         $hexa_integer = "0xFFAB01";
         $decimal_double = "124.1323";
+        $decimal_double_exp = "124.1323e+100";
+        $decimal_double_exp_neg = "024e-25";
+        $decimal_double_exp_pos = "024e+25";
         $decimal_non_octal_double = "0314.0";
         $binary_integer = "0b11111111";
         $binary_invalid = "0b1019";
 
         $this->assertEquals("[T_INTEGER, 1083]", $this->tokenize($decimal_integer, SHOW_SYMBOL_TABLE));
-        $this->assertEquals("[T_INTEGER, 0314]", $this->tokenize($octal_integer, SHOW_SYMBOL_TABLE));
-        $this->assertEquals("[T_INTEGER, 0314]", $this->tokenize($octal_partial_integer, SHOW_SYMBOL_TABLE));
-        $this->assertEquals("[T_INTEGER, 0xFFAB01]", $this->tokenize($hexa_integer, SHOW_SYMBOL_TABLE));
+        $this->assertEquals("[T_INT_OCT, 0o314]", $this->tokenize($octal_integer, SHOW_SYMBOL_TABLE));
+        $this->assertEquals("[T_INT_OCT, 0o314][T_INTEGER, 891]", $this->tokenize($octal_partial_integer, SHOW_SYMBOL_TABLE));
+        $this->assertEquals("[T_INT_HEX, 0xFFAB01]", $this->tokenize($hexa_integer, SHOW_SYMBOL_TABLE));
         $this->assertEquals("[T_DOUBLE, 124.1323]", $this->tokenize($decimal_double, SHOW_SYMBOL_TABLE));
+        $this->assertEquals("[T_DOUBLE_EXP, 124.1323e+100]", $this->tokenize($decimal_double_exp, SHOW_SYMBOL_TABLE));
+        $this->assertEquals("[T_DOUBLE_EXP, 024e-25]", $this->tokenize($decimal_double_exp_neg, SHOW_SYMBOL_TABLE));
+        $this->assertEquals("[T_DOUBLE_EXP, 024e+25]", $this->tokenize($decimal_double_exp_pos, SHOW_SYMBOL_TABLE));
         $this->assertEquals("[T_DOUBLE, 0314.0]", $this->tokenize($decimal_non_octal_double, SHOW_SYMBOL_TABLE));
-        $this->assertEquals("[T_INTEGER, 0b11111111]", $this->tokenize($binary_integer, SHOW_SYMBOL_TABLE));
-        $this->assertEquals("[T_INTEGER, 0b101][T_INTEGER, 9]", $this->tokenize($binary_invalid, SHOW_SYMBOL_TABLE));
+        $this->assertEquals("[T_INT_BIN, 0b11111111]", $this->tokenize($binary_integer, SHOW_SYMBOL_TABLE));
+        $this->assertEquals("[T_INT_BIN, 0b101][T_INTEGER, 9]", $this->tokenize($binary_invalid, SHOW_SYMBOL_TABLE));
     }
 
     public function testString()

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -33,6 +33,8 @@ class LexerTest extends \PHPUnit_Framework_TestCase
         $hexa_integer = "0xFFAB01";
         $decimal_double = "124.1323";
         $decimal_double_exp = "124.1323e+100";
+        $double_exp_no_signal = "122e1";
+        $double_exp_no_signal_fake = "122eb";
         $decimal_double_exp_neg = "024e-25";
         $decimal_double_exp_pos = "024e+25";
         $decimal_non_octal_double = "0314.0";
@@ -44,6 +46,8 @@ class LexerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("[T_INT_OCT, 0o314][T_INTEGER, 891]", $this->tokenize($octal_partial_integer, SHOW_SYMBOL_TABLE));
         $this->assertEquals("[T_INT_HEX, 0xFFAB01]", $this->tokenize($hexa_integer, SHOW_SYMBOL_TABLE));
         $this->assertEquals("[T_DOUBLE, 124.1323]", $this->tokenize($decimal_double, SHOW_SYMBOL_TABLE));
+        $this->assertEquals("[T_DOUBLE_EXP, 122e1]", $this->tokenize($double_exp_no_signal, SHOW_SYMBOL_TABLE));
+        $this->assertEquals("[T_INTEGER, 122][T_IDENT, eb]", $this->tokenize($double_exp_no_signal_fake, SHOW_SYMBOL_TABLE));
         $this->assertEquals("[T_DOUBLE_EXP, 124.1323e+100]", $this->tokenize($decimal_double_exp, SHOW_SYMBOL_TABLE));
         $this->assertEquals("[T_DOUBLE_EXP, 024e-25]", $this->tokenize($decimal_double_exp_neg, SHOW_SYMBOL_TABLE));
         $this->assertEquals("[T_DOUBLE_EXP, 024e+25]", $this->tokenize($decimal_double_exp_pos, SHOW_SYMBOL_TABLE));


### PR DESCRIPTION
This PR makes Quack numbers consistent by changing some old rules. In this way, we do not need to use PHP notation anymore.

There are numerous inconsistencies in PHP such as:
  - Hexadecimal notation can be represented by `0xFFfff0` and `0XFFfff0`
  - Binary notation is only represented by `0b0001` (`0B0001` is not valid).
  - Octal notation is weird: `0666` (__?__) `// isn't that a decimal notation number?`

This PR is redefining Quack numbers to:

|              | Decimal |  Binary | Octal | Hexadecimal  | Double | Double Exp |
| :--------: | :---------: | :----------: | :------: | :------: | :----------------: | :--------------: |
| __Then__  |  2222   | 0`[bB]`10011010  | 0765  | 0`[xX]`FA19  |  3.1415  |  - |
| __Now__  |   2222 |  0`b`10011010 |  0`o`765   | 0`x`FA19  |  3.1415  | 2.15`e[+-]`10 |

In order to ease our future tasks of analysing number types (such as comparison optimizations and reducing the complexity of always checking a number), I included new `Tag` types: `T_INT_OCT`, `T_INT_BIN`, `T_INT_HEX` and `T_DOUBLE_EXP`. Thus, I also created a member named `notation` inside the `NumberExpr` class. Having said that, `octal`, `binary` and `hexadecimal` notation numbers are still __int__ and `scientific` notation ones are __double__.

Obs.: If we took `Quack` only as a Transpiler, we wouldn't need to check those numbers, however, the Quack project is big and I am thinking about the future implications of not having those tags. 

------------------------------------------------------------------
- `digit()` is now using the `KMP` algorithm approach for `octal`, `binary` and `hexadecimal` notations.

 - The second part (checking for floating numbers) uses a basic state machine:

![photo435744009096374236](https://cloud.githubusercontent.com/assets/6173065/20050420/1a68da88-a47e-11e6-903c-2d6733fe80c5.jpg)

