### PR TITLE
Add JEST-like colors for tests

### DIFF
--- a/src/lexer/Tokenizer.php
+++ b/src/lexer/Tokenizer.php
@@ -116,7 +116,7 @@ class Tokenizer extends Lexer
             }
 
             $value = implode($buffer);
-            $this->column += sizeof($value);
+            $this->column += sizeof($buffer);
 
             return new Token(Tag::T_INTEGER, $this->symbol_table->add($value));
         }

--- a/tools/testsuite/run-tests.hy
+++ b/tools/testsuite/run-tests.hy
@@ -28,7 +28,7 @@
         [fnmatch]
         [shutil [rmtree]]
         [ntpath [basename]]
-        [termcolor [colored]]
+        [termcolor [colored cprint]]
         [difflib])
 
 (def **version** "Quack test toolkit v0.0.1-alpha")
@@ -166,18 +166,12 @@
     (if (= output stripped-to-compare)
       (do
         (setv passed (inc passed))
-        (print (colored (-> "Pass: "
-          (+ file)
-          (+ " - ")
-          (+ (:describe section))) "green")))
+        (cprint "PASS" "white" "on_green" :attrs ["bold"] :end " ")
+        (print (-> file (+ " - ") (+ (:describe section)))))
       (do
         (setv failed (inc failed))
-        (print
-          (colored
-            (-> "Fail: "
-              (+ file)
-              (+ " - ")
-              (+ (:describe section))) "red"))
+        (cprint "FAIL" "white" "on_red" :attrs ["bold"] :end " ")
+        (print (-> file (+ " - ") (+ (:describe section))))
         (print "Difference:")
         (setv output-list
           (-> output (.split linesep)))


### PR DESCRIPTION
# Bitches, I'm back!

![2017-02-08-111347_856x518_scrot](https://cloud.githubusercontent.com/assets/7553006/22738836/39bb4a86-edf0-11e6-8b0e-8e746a871b5e.png)

Now the `PASS` and `FAIL` flags have background colors for Quack tests.