### PR TITLE
Fixes on labels

### DIFF
--- a/src/ast/expr/NameExpr.php
+++ b/src/ast/expr/NameExpr.php
@@ -21,10 +21,13 @@
  */
 namespace QuackCompiler\Ast\Expr;
 
+use \QuackCompiler\Intl\Localization;
 use \QuackCompiler\Parser\Parser;
+use \QuackCompiler\Scope\Kind;
 use \QuackCompiler\Scope\Meta;
 use \QuackCompiler\Scope\ScopeError;
 use \QuackCompiler\Types\Type;
+use \QuackCompiler\Types\TypeError;
 
 class NameExpr extends Expr
 {
@@ -69,8 +72,13 @@ class NameExpr extends Expr
 
     public function getType()
     {
-        $variable_scope = $this->scoperef->getSymbolScope($this->name);
-        $vartype = $variable_scope->getMeta(Meta::M_TYPE, $this->name);
-        return $vartype;
+        $symbol = $this->scoperef->lookup($this->name);
+
+        if ($symbol & Kind::K_VARIABLE) {
+            $variable_scope = $this->scoperef->getSymbolScope($this->name);
+            return $variable_scope->getMeta(Meta::M_TYPE, $this->name);
+        }
+
+        throw new TypeError(Localization::message('TYP190', [$this->name]));
     }
 }

--- a/src/ast/stmt/LabelStmt.php
+++ b/src/ast/stmt/LabelStmt.php
@@ -38,8 +38,7 @@ class LabelStmt extends Stmt
 
     public function format(Parser $parser)
     {
-        $source = ':- ';
-        $source .= $this->name;
+        $source = '[' . $this->name . ']';
         $source .= PHP_EOL;
         $source .= $this->stmt->format($parser);
         return $source;

--- a/src/intl/locales/en-US.json
+++ b/src/intl/locales/en-US.json
@@ -16,5 +16,6 @@
     "TYP150": "Expecting type of case of switch statement to be `%s'. Got `%s'",
     "TYP160": "More than one else clause for switch statement",
     "TYP170": "Expecting type of field `%s' of foreach statement to be a `number'. Got `%s'",
-    "TYP180": "Condition passed to elif statement should be a `boolean', not a `%s'"
+    "TYP180": "Condition passed to elif statement should be a `boolean', not a `%s'",
+    "TYP190": "Cannot infer type of non-variable `%s'"
 }

--- a/src/parser/Grammar.php
+++ b/src/parser/Grammar.php
@@ -113,7 +113,7 @@ class Grammar
             Tag::T_RAISE    => '_raiseStmt',
             Tag::T_BEGIN    => '_blockStmt',
             '^'             => '_returnStmt',
-            ':-'            => '_labelStmt'
+            '['             => '_labelStmt'
         ];
 
         foreach ($branch_table as $token => $action) {
@@ -314,8 +314,9 @@ class Grammar
 
     public function _labelStmt()
     {
-        $this->parser->match(':-');
+        $this->parser->match('[');
         $label_name = $this->identifier();
+        $this->parser->match(']');
         $stmt = $this->_innerStmt();
 
         return new LabelStmt($label_name, $stmt);

--- a/src/parser/TokenChecker.php
+++ b/src/parser/TokenChecker.php
@@ -63,7 +63,7 @@ class TokenChecker
             Tag::T_RAISE,
             Tag::T_BEGIN,
             '^',
-            ':-'
+            '['
         ];
 
         $next_tag = $this->parser->lookahead->getTag();

--- a/tests/stmt/break_stmt.qtest
+++ b/tests/stmt/break_stmt.qtest
@@ -1,13 +1,13 @@
 %%describe
 Supports formatting break
 %%source
-:- id for i from 0 to 10 if i = 2 break id end end
+[id] for i from 0 to 10 if i = 2 break id end end
 
 for j from -1 to 0
 break
 end
 %%expect
-:- id
+[id]
 for i from 0 to 10
   if i = 2
     break id

--- a/tests/stmt/continue_stmt.qtest
+++ b/tests/stmt/continue_stmt.qtest
@@ -1,14 +1,14 @@
 %%describe
 Supports formatting continue
 %%source
-:- id for i from 1 to 10 while true continue id end end --scape infinite loop
+[id] for i from 1 to 10 while true continue id end end --scape infinite loop
 
 for j from 0 to 100
 
 continue
 end
 %%expect
-:- id
+[id]
 for i from 1 to 10
   while true
     continue id

--- a/tests/stmt/elif_stmt.qtest
+++ b/tests/stmt/elif_stmt.qtest
@@ -3,7 +3,7 @@ Supports formatting if statements
 %%source
 if 1 > 0 do console.writeline("One is greater than zero") elif true {-do nothing-}end
 
-:- firstLabel
+[ firstLabel ]
 for i from 1 to 10 by 2
   for j from 1 to 10
     if (i = 3) and (j =~ 0)
@@ -18,7 +18,7 @@ if 1 > 0
   do console.writeline("One is greater than zero")
 elif true
 end
-:- firstLabel
+[firstLabel]
 for i from 1 to 10 by 2
   for j from 1 to 10
     if (i = 3) and (j =~ 0)


### PR DESCRIPTION
This pull-request does:

- Change label syntax from `:- label` to `[label]`, fixing ambiguity on `for i from x to 10 :- label end`, because `(:-)` is no more prefix and infix
- Fix bug when referring to something that is not a variable inside an expression, such as `[x] do x` (previously `:- x do x`