### PR TITLE
Resolve all type errors internationalization

### DIFF
--- a/src/ast/expr/PrefixExpr.php
+++ b/src/ast/expr/PrefixExpr.php
@@ -21,6 +21,7 @@
  */
 namespace QuackCompiler\Ast\Expr;
 
+use \QuackCompiler\Intl\Localization;
 use \QuackCompiler\Lexer\Tag;
 use \QuackCompiler\Lexer\Token;
 use \QuackCompiler\Parser\Parser;
@@ -57,9 +58,7 @@ class PrefixExpr extends Expr
         $right_type = $this->right->getType();
         $op_name = Tag::getOperatorLexeme($this->operator);
 
-        $type_error = new TypeError(
-            "No type overload for operator `{$op_name}' for `{$right_type}'"
-        );
+        $type_error = new TypeError(Localization::message('TYP230', [$op_name, $right_type]));
 
         switch ($this->operator) {
             case '+':

--- a/src/ast/expr/RangeExpr.php
+++ b/src/ast/expr/RangeExpr.php
@@ -21,6 +21,7 @@
  */
 namespace QuackCompiler\Ast\Expr;
 
+use \QuackCompiler\Intl\Localization;
 use \QuackCompiler\Parser\Parser;
 use \QuackCompiler\Types\NativeQuackType;
 use \QuackCompiler\Types\Type;
@@ -74,9 +75,7 @@ class RangeExpr extends Expr
         ];
 
         $throw_error_on = function ($operand, $got) {
-            throw new TypeError(
-                "Expected number on operand `{$operand}' of range expression. Got {$got}"
-            );
+            throw new TypeError(Localization::message('TYP220', [$operand, $got]));
         };
 
         if (!$type->from->isNumber()) {

--- a/src/ast/expr/TernaryExpr.php
+++ b/src/ast/expr/TernaryExpr.php
@@ -21,6 +21,7 @@
  */
 namespace QuackCompiler\Ast\Expr;
 
+use \QuackCompiler\Intl\Localization;
 use \QuackCompiler\Parser\Parser;
 use \QuackCompiler\Types\NativeQuackType;
 use \QuackCompiler\Types\Type;
@@ -61,19 +62,14 @@ class TernaryExpr extends Expr
     {
         $condition_type = $this->condition->getType();
         if (NativeQuackType::T_BOOL !== $condition_type->code) {
-            throw new TypeError(
-                "Condition of ternary operator should de `boolean'. Got `{$condition_type}'"
-            );
+            throw new TypeError(Localization::message('TYP240', [$condition_type]));
         }
 
         $when_true_type = $this->then->getType();
         $when_false_type = $this->else->getType();
 
         if (!$when_true_type->isExactlySameAs($when_false_type)) {
-            throw new TypeError(
-                "Both sides of ternary expression must have the same type. Got " .
-                "`$when_true_type' and `$when_false_type'"
-            );
+            throw new TypeError(Localization::message('TYP250', [$when_true_type, $when_false_type]));
         }
 
         return clone $when_true_type;

--- a/src/ast/expr/WhenExpr.php
+++ b/src/ast/expr/WhenExpr.php
@@ -21,6 +21,7 @@
  */
 namespace QuackCompiler\Ast\Expr;
 
+use \QuackCompiler\Intl\Localization;
 use \QuackCompiler\Parser\Parser;
 use \QuackCompiler\Types\NativeQuackType;
 use \QuackCompiler\Types\Type;
@@ -95,9 +96,7 @@ class WhenExpr extends Expr
                 $condition_type = $case->condition->getType();
 
                 if (!$condition_type->isBoolean()) {
-                    throw new TypeError(
-                        "Expected condition {$conds} of `when' to be boolean. Got `$condition_type'"
-                    );
+                    throw new TypeError(Localization::message('TYP200', [$conds, $condition_type]));
                 }
             }
 
@@ -107,9 +106,7 @@ class WhenExpr extends Expr
                 $type = $action_type;
             } else if (!$type->isExactlySameAs($action_type)) {
                 // After initializing the first type, let's compare the others
-                throw new TypeError(
-                    "All conditions of cond must have same type `{$type}'. Cond {$conds} is `{$action_type}'"
-                );
+                throw new TypeError(Localization::message('TYP210', [$type, $conds, $action_type]));
             }
         }
 

--- a/src/intl/Localization.php
+++ b/src/intl/Localization.php
@@ -32,8 +32,7 @@ class Localization
             static::$messages = static::readJSON();
         }
 
-        return call_user_func_array('sprintf',
-            array_merge([static::$messages[$key]], $arguments));
+        return sprintf(...array_merge([static::$messages[$key]], $arguments));
     }
 
     private static function readJSON()

--- a/src/intl/locales/en-US.json
+++ b/src/intl/locales/en-US.json
@@ -17,5 +17,11 @@
     "TYP160": "More than one else clause for switch statement",
     "TYP170": "Expecting type of field `%s' of foreach statement to be a `number'. Got `%s'",
     "TYP180": "Condition passed to elif statement should be a `boolean', not a `%s'",
-    "TYP190": "Cannot infer type of non-variable `%s'"
+    "TYP190": "Cannot infer type of non-variable `%s'",
+    "TYP200": "Expected condition %d of when expression to be a `boolean'. Got `%s'",
+    "TYP210": "All results to when expression must be of same type `%s', but result %d is `%s'",
+    "TYP220": "Expected a `number' on operand `%s' of range expression. Got `%s'",
+    "TYP230": "No type overload for operator `%s' on type `%s'",
+    "TYP240": "Condition of ternary operator should de `boolean'. Got `%s'",
+    "TYP250": "Both sides of ternary expression must have the same type. Got `%s' and `%s'"
 }


### PR DESCRIPTION
This pull-request does:

- Adapt all remaining `TypeError` to use `Localization::message`
- Use PHP5 argument expansion with `...` instead of using `call_user_func_array` on function `message` of `Localization`