### PR TITLE
Fix format for label statement

### DIFF
--- a/src/ast/stmt/LabelStmt.php
+++ b/src/ast/stmt/LabelStmt.php
@@ -40,6 +40,7 @@ class LabelStmt extends Stmt
     {
         $source = '[' . $this->name . ']';
         $source .= PHP_EOL;
+        $source .= $parser->indent();
         $source .= $this->stmt->format($parser);
         return $source;
     }

--- a/tests/stmt/break_stmt.qtest
+++ b/tests/stmt/break_stmt.qtest
@@ -1,7 +1,11 @@
 %%describe
 Supports formatting break
 %%source
-[id] for i from 0 to 10 if i = 2 break id end end
+[id] for i from 0 to 10
+  [another] for j from 0 to 10 by 2
+  if i = 2 break id end
+  end
+end
 
 for j from -1 to 0
 break
@@ -9,8 +13,11 @@ end
 %%expect
 [id]
 for i from 0 to 10
-  if i = 2
-    break id
+  [another]
+  for j from 0 to 10 by 2
+    if i = 2
+      break id
+    end
   end
 end
 for j from -1 to 0


### PR DESCRIPTION
### Before:

```ruby
[firstLabel]
for i from 1 to 10 by 2
  [secondLabel]
for j from 1 to 10
    if (i = 3) and (j =~ 0)
      break firstLabel
    elif (i =~ 2)
      continue firstLabel
    end
  end
end
```

### Now

```ruby
[firstLabel]
for i from 1 to 10 by 2
  [secondLabel]
  for j from 1 to 10
    if (i = 3) and (j =~ 0)
      break firstLabel
    elif (i =~ 2)
      continue firstLabel
    end
  end
end
```