### PR TITLE
Errors localization and small fixes

### DIFF
--- a/TYPECHECKER_TODO.md
+++ b/TYPECHECKER_TODO.md
@@ -7,7 +7,6 @@ Sprint 1:
 - [x] Short method syntax
 - [x] Classes over traits
 - [x] Shapes over structs
-- [ ] Object initializer with maps
 - [x] Parenthesis on function calls and definitions
 - [x] Impl with implicit `fn'
 - [x] Change syntax for comments
@@ -17,26 +16,23 @@ Sprint 1:
 Sprint 2:
 
 - [x] Run typechecker on TryStmt
-- [ ] Traverse AST first time to get declarations and bind to scope
 - [x] Run typechecker on ContinueStmt
 - [x] Run typechecker on BreakStmt
-- [ ] Implement parser for type signatures
-- [ ] Implement sum-types and type combinators
 - [x] Run typechecker on SwitchStmt and CaseStmt
 - [x] Run typechecker on ElifStmt
-- [ ] Run and implement type checker and reasoning for FnStmt
 - [x] Run typechecker on ForeachStmt
 - [x] Run typechecker on LabelStmt
 - [x] Run typechecker on ForStmt
-- [ ] Create default class TypeError and replace some of ScopeError that are specific for types
-- [ ] Record, in the AST, the positions of the symbols, in order to give better error messages
-- [ ] Run typechecker and see type rules for bluerprints, traits, structs and impls
-- [ ] Run typechecker for MemberStmt
-- [ ] Implement supertype and subtype structural (and nominal) comparators [Duck typing]
+- [x] Create default class TypeError and replace some of ScopeError that are specific for types
 - [x] Skip typechecker over ModuleStmt and OpenStmt
-- [ ] Run typechecker for RaiseStmt, ensure derivation from \Exception
-- [ ] Assert the context of ReturnStmt and pass the expected return type to it when inside functions
-- [ ] Implement subtyping for arrays and maps (check implementation of sum-types)
 - [x] Inject type for variable in ForStmt
 - [x] Inject type for variable in ForeachStmt
 - [x] Remove difference between number types for type checking
+- [x] Traverse AST first time to get declarations and bind to scope
+
+- [ ] Implement parser for type signatures
+- [ ] Run and implement type checker and reasoning for FnStmt
+- [ ] Record, in the AST, the positions of the symbols, in order to give better error messages
+- [ ] Run typechecker and see type rules for bluerprints, traits, structs and impls
+- [ ] Run typechecker for RaiseStmt, ensure derivation from \Exception
+- [ ] Assert the context of ReturnStmt and pass the expected return type to it when inside functions

--- a/src/ast/Node.php
+++ b/src/ast/Node.php
@@ -22,6 +22,7 @@
 namespace QuackCompiler\Ast;
 
 use \QuackCompiler\Ast\Stmt\ConstStmt;
+use \QuackCompiler\Intl\Localization;
 use \QuackCompiler\Parser\Parser;
 use \QuackCompiler\Scope\Kind;
 use \QuackCompiler\Scope\Scope;
@@ -48,9 +49,7 @@ abstract class Node
             $value = &$def[1];
 
             if ($this->scope->hasLocal($name)) {
-                throw new ScopeError([
-                    'message' => "Symbol `{$name}' declared twice"
-                ]);
+                throw new ScopeError(Localization::message('SCO130', [$name, 'variable']));
             }
 
             $bitfield = Kind::K_VARIABLE;
@@ -68,9 +67,7 @@ abstract class Node
     private function bindDecl($named_node, $type, $kind)
     {
         if ($this->scope->hasLocal($named_node->name)) {
-            throw new ScopeError([
-                'message' => "Symbol for {$type} `{$named_node->name}' declared twice"
-            ]);
+            throw new ScopeError(Localization::message('SCO130', [$named_node->name, $type]));
         }
 
         // When it is a function and it is marked as public

--- a/src/ast/expr/LambdaExpr.php
+++ b/src/ast/expr/LambdaExpr.php
@@ -21,6 +21,7 @@
  */
 namespace QuackCompiler\Ast\Expr;
 
+use \QuackCompiler\Intl\Localization;
 use \QuackCompiler\Parselets\LambdaParselet;
 use \QuackCompiler\Parser\Parser;
 use \QuackCompiler\Scope\Kind;
@@ -96,9 +97,7 @@ class LambdaExpr extends Expr
 
         foreach ($this->parameters as $param) {
             if ($this->scope->hasLocal($param->name)) {
-                throw new ScopeError([
-                    'message' => "Duplicated parameter `{$param->name}' in anonymous function"
-                ]);
+                throw new ScopeError(Localization::message('SCO010', [$param->name]));
             }
 
             $this->scope->insert($param->name, Kind::K_INITIALIZED | Kind::K_VARIABLE | Kind::K_PARAMETER | Kind::K_MUTABLE);

--- a/src/ast/expr/NameExpr.php
+++ b/src/ast/expr/NameExpr.php
@@ -52,9 +52,7 @@ class NameExpr extends Expr
         $symbol = $parent_scope->lookup($this->name);
 
         if (null === $symbol) {
-            throw new ScopeError([
-                'message' => "Use of undefined variable `{$this->name}'"
-            ]);
+            throw new ScopeError(Localization::message('SCO020', [$this->name]));
         }
 
         // When we reach here, we can compute that this symbol is being used

--- a/src/ast/expr/NameExpr.php
+++ b/src/ast/expr/NameExpr.php
@@ -48,7 +48,6 @@ class NameExpr extends Expr
     public function injectScope(&$parent_scope)
     {
         $this->scoperef = &$parent_scope;
-        // TODO: Check symbol kind in order to provide better messages
         $symbol = $parent_scope->lookup($this->name);
 
         if (null === $symbol) {

--- a/src/ast/expr/NewExpr.php
+++ b/src/ast/expr/NewExpr.php
@@ -21,6 +21,7 @@
  */
 namespace QuackCompiler\Ast\Expr;
 
+use \QuackCompiler\Intl\Localization;
 use \QuackCompiler\Parser\Parser;
 use \QuackCompiler\Scope\Kind;
 use \QuackCompiler\Scope\ScopeError;
@@ -55,16 +56,12 @@ class NewExpr extends Expr
 
         // When symbol doesn't exist
         if (null === $class) {
-            throw new ScopeError([
-                'message' => "Undefined shape `{$name}'"
-            ]);
+            throw new ScopeError(Localization::message('SCO030', [$name]));
         }
 
         // When symbol is not a shape
         if (~$class & Kind::K_SHAPE) {
-            throw new ScopeError([
-                'message' => "Cannot instantiate `{$name}'. Not a shape"
-            ]);
+            throw new ScopeError(Localization::message('SCO040', [$name]));
         }
 
         // TODO: Inject scope on initializer (if provided)

--- a/src/ast/expr/ObjectExpr.php
+++ b/src/ast/expr/ObjectExpr.php
@@ -21,6 +21,7 @@
  */
 namespace QuackCompiler\Ast\Expr;
 
+use \QuackCompiler\Intl\Localization;
 use \QuackCompiler\Parser\Parser;
 use \QuackCompiler\Scope\ScopeError;
 use \QuackCompiler\Types\NativeQuackType;
@@ -80,9 +81,7 @@ class ObjectExpr extends Expr
             $value = $this->values[$index];
 
             if (array_key_exists($key, $defined)) {
-                throw new ScopeError([
-                    'message' => "Duplicated object property `${key}'"
-                ]);
+                throw new ScopeError(Localization::message('SCO050', [$key]));
             }
 
             $value->injectScope($parent_scope);

--- a/src/ast/expr/OperatorExpr.php
+++ b/src/ast/expr/OperatorExpr.php
@@ -77,16 +77,12 @@ class OperatorExpr extends Expr
 
                 // When symbol is not a variable
                 if (~$symbol & Kind::K_VARIABLE) {
-                    throw new ScopeError([
-                        'message' => "Symbol `{$this->left->name}' is not a variable"
-                    ]);
+                    throw new ScopeError(Localization::message('SCO070', [$this->left->name]));
                 }
 
                 // When symbol is not mutable
                 if (~$symbol & Kind::K_MUTABLE) {
-                    throw new ScopeError([
-                        'message' => "Symbol `{$this->left->name}' is immutable"
-                    ]);
+                    throw new ScopeError(Localization::message('SCO080', [$this->left->name]));
                 }
             } else {
                 // We have a range of specific nodes that are allowed
@@ -94,18 +90,15 @@ class OperatorExpr extends Expr
                     $this->left instanceof ArrayExpr; // Array destructuring
 
                 if (!$valid_assignment) {
-                    throw new ScopeError([
-                        'message' => "Invalid left-hand side in assignment"
-                    ]);
+                    throw new ScopeError(Localization::message('SCO090', []));
                 }
 
                 // When it is array destructuring, ensure all the subnodes are names
+                // TODO: Implement destructuring on let, because this is currently useless
                 if ($this->left instanceof ArrayExpr) {
                     foreach ($this->left->items as $item) {
                         if (!($item instanceof NameExpr)) {
-                            throw new ScopeError([
-                                'message' => "Array destructuring expects all children to be names"
-                            ]);
+                            throw new ScopeError(Localization::message('SCO100', []));
                         }
                     }
                 }

--- a/src/ast/expr/PostfixExpr.php
+++ b/src/ast/expr/PostfixExpr.php
@@ -52,8 +52,6 @@ class PostfixExpr extends Expr
 
     public function getType()
     {
-        // TODO: Check implementations of postfix expressions.
-        // Currently, there is none
         return new Type(NativeQuackType::T_LAZY);
     }
 }

--- a/src/ast/expr/WhereExpr.php
+++ b/src/ast/expr/WhereExpr.php
@@ -95,7 +95,7 @@ class WhereExpr extends Expr
             }
 
             $value->injectScope($this->scope);
-            $this->scope->insert($key, Kind::K_VARIABLE | Kind::K_VIRTUAL | Kind::K_INITIALIZED);
+            $this->scope->insert($key, Kind::K_VARIABLE | Kind::K_INITIALIZED);
         }
 
         $this->expr->injectScope($this->scope);

--- a/src/ast/expr/WhereExpr.php
+++ b/src/ast/expr/WhereExpr.php
@@ -21,6 +21,7 @@
  */
 namespace QuackCompiler\Ast\Expr;
 
+use \QuackCompiler\Intl\Localization;
 use \QuackCompiler\Parser\Parser;
 use \QuackCompiler\Scope\Kind;
 use \QuackCompiler\Scope\Meta;
@@ -90,9 +91,7 @@ class WhereExpr extends Expr
             $value = &$clause[1];
 
             if ($this->scope->hasLocal($key)) {
-                throw new ScopeError([
-                    'message' => "Duplicated declaration of `{$key}' on where-clause"
-                ]);
+                throw new ScopeError(Localization::message('SCO120', [$key]));
             }
 
             $value->injectScope($this->scope);

--- a/src/ast/stmt/BreakStmt.php
+++ b/src/ast/stmt/BreakStmt.php
@@ -21,6 +21,7 @@
  */
 namespace QuackCompiler\Ast\Stmt;
 
+use \QuackCompiler\Intl\Localization;
 use \QuackCompiler\Parser\Parser;
 use \QuackCompiler\Scope\Kind;
 use \QuackCompiler\Scope\Meta;
@@ -59,25 +60,19 @@ class BreakStmt extends Stmt
             // If there is no implicit labels in the context, then the user is
             // calling 'break' outsite a loop.
             if (null === $label) {
-                throw new ScopeError([
-                    'message' => "Called `break' outsite a loop"
-                ]);
+                throw new ScopeError(Localization::message('SCO140', ['break']));
             }
         } else {
             $label = $parent_scope->lookup($this->label);
 
             // When the symbol doesn't exist
             if (null === $label) {
-                throw new ScopeError([
-                    'message' => "Called `break' with undefined label `{$this->label}'"
-                ]);
+                throw new ScopeError(Localization::message('SCO150', ['break', $this->label]));
             }
 
             // When the symbol exist, but it's not a label
             if (~$label & Kind::K_LABEL) {
-                throw new ScopeError([
-                    'message' => "Called `break' with invalid label `{$this->label}'"
-                ]);
+                throw new ScopeError(Localization::message('SCO160', ['break', $this->label]));
             }
 
             $refcount = &$parent_scope->getMeta(Meta::M_REF_COUNT, $this->label);

--- a/src/ast/stmt/ContinueStmt.php
+++ b/src/ast/stmt/ContinueStmt.php
@@ -21,6 +21,7 @@
  */
 namespace QuackCompiler\Ast\Stmt;
 
+use \QuackCompiler\Intl\Localization;
 use \QuackCompiler\Parser\Parser;
 use \QuackCompiler\Scope\Kind;
 use \QuackCompiler\Scope\Meta;
@@ -59,26 +60,20 @@ class ContinueStmt extends Stmt
             // If there is no implicit labels in the context, then the user is
             // calling 'continue' outsite a loop.
             if (null === $label) {
-                throw new ScopeError([
-                    'message' => "Called `continue' outsite a loop"
-                ]);
+                throw new ScopeError(Localization::message('SCO140', ['continue']));
             }
         } else {
             $label = $parent_scope->lookup($this->label);
 
             // When the symbol doesn't exist
             if (null === $label) {
-                throw new ScopeError([
-                    'message' => "Called `continue' with undefined label `{$this->label}'"
-                ]);
+                throw new ScopeError(Localization::message('SCO150', ['continue', $this->label]));
             }
 
             // When the symbol exist, but it's not a label
             if (~$label & Kind::K_LABEL) {
                 // When the symbol exist, but it's not a label
-                throw new ScopeError([
-                    'message' => "Called `continue' with invalid label `{$this->label}'"
-                ]);
+                throw new ScopeError(Localization::message('SCO160', ['continue', $this->label]));
             }
 
             $refcount = &$parent_scope->getMeta(Meta::M_REF_COUNT, $this->label);

--- a/src/ast/stmt/EnumStmt.php
+++ b/src/ast/stmt/EnumStmt.php
@@ -21,6 +21,7 @@
  */
 namespace QuackCompiler\Ast\Stmt;
 
+use \QuackCompiler\Intl\Localization;
 use \QuackCompiler\Parser\Parser;
 use \QuackCompiler\Scope\Membered;
 use \QuackCompiler\Scope\Kind;
@@ -69,10 +70,7 @@ class EnumStmt extends Stmt implements Membered
         // Inject its own members
         foreach ($this->entries as $entry) {
             if ($this->scope->hasLocal($entry)) {
-                throw new ScopeError([
-                    'message' => "Duplicated declaration of `{$entry}' for enum " .
-                                 $this->name
-                ]);
+                throw new ScopeError(Localization::message('SCO170', [$entry, $this->name]));
             }
 
             $this->scope->insert($entry, Kind::K_MEMBER | Kind::K_INITIALIZED);

--- a/src/ast/stmt/FnStmt.php
+++ b/src/ast/stmt/FnStmt.php
@@ -21,6 +21,7 @@
  */
 namespace QuackCompiler\Ast\Stmt;
 
+use \QuackCompiler\Intl\Localization;
 use \QuackCompiler\Parser\Parser;
 use \QuackCompiler\Scope\Kind;
 use \QuackCompiler\Scope\ScopeError;
@@ -106,9 +107,7 @@ class FnStmt extends Stmt
         // Pre-inject parameters
         foreach ($this->signature->parameters as $param) {
             if ($this->scope->hasLocal($param->name)) {
-                throw new ScopeError([
-                    'message' => "Duplicated parameter `{$param->name}' in function {$this->signature->name}"
-                ]);
+                throw new ScopeError(Localization::message('SCO060', [$param->name, $this->signature->name]));
             }
 
             $this->scope->insert($param->name, Kind::K_INITIALIZED | Kind::K_MUTABLE | Kind::K_VARIABLE | Kind::K_PARAMETER);

--- a/src/ast/stmt/ForStmt.php
+++ b/src/ast/stmt/ForStmt.php
@@ -109,12 +109,7 @@ class ForStmt extends Stmt
             }
         }
 
-        // TODO: Remove covariance (at least for now)
-        // Bind inferred type for variable
-        $this->scope->setMeta(Meta::M_TYPE, $this->variable, new Type(array_reduce($keys, function ($acc, $key) {
-            return max($acc, $this->{$key}->getType()->code);
-        })));
-
+        $this->scope->setMeta(Meta::M_TYPE, $this->variable, new Type(NativeQuackType::T_NUMBER));
         $this->body->runTypeChecker();
     }
 }

--- a/src/ast/stmt/ForeachStmt.php
+++ b/src/ast/stmt/ForeachStmt.php
@@ -22,12 +22,14 @@
 namespace QuackCompiler\Ast\Stmt;
 
 use \QuackCompiler\Ast\Util;
+use \QuackCompiler\Intl\Localization;
 use \QuackCompiler\Parser\Parser;
 use \QuackCompiler\Scope\Kind;
 use \QuackCompiler\Scope\Meta;
 use \QuackCompiler\Scope\ScopeError;
 use \QuackCompiler\Types\NativeQuackType;
 use \QuackCompiler\Types\Type;
+use \QuackCompiler\Types\TypeError;
 
 class ForeachStmt extends Stmt
 {
@@ -52,7 +54,7 @@ class ForeachStmt extends Stmt
 
         if (null !== $this->key) {
             $source .= $this->key;
-            $source .= ' -> ';
+            $source .= ': ';
         }
 
         if ($this->by_reference) {
@@ -92,10 +94,7 @@ class ForeachStmt extends Stmt
         }
 
         if ($this->key === $this->alias) {
-            throw new ScopeError([
-                'message' => "Same key and value variable name " .
-                             "(`{$this->alias}') supplied for foreach"
-            ]);
+            throw new ScopeError(Localization::message('SCO180', [$this->alias]));
         }
 
         $this->scope->insert($this->alias, Kind::K_VARIABLE | Kind::K_INITIALIZED | Kind::K_MUTABLE);
@@ -116,9 +115,7 @@ class ForeachStmt extends Stmt
 
         // When the element has no subtype to be an iterable
         if (null === $generator_type->subtype)  {
-            throw new ScopeError([
-                'message' => "`{$generator_type}' is not iterable"
-            ]);
+            throw new TypeError(Localization::message('TYP260', [$generator_type]));
         }
 
         // When the element has no deducible subtype (list)

--- a/src/ast/stmt/ForeachStmt.php
+++ b/src/ast/stmt/ForeachStmt.php
@@ -119,20 +119,14 @@ class ForeachStmt extends Stmt
         }
 
         // When the element has no deducible subtype (list)
-        if (!is_array($generator_type->subtype) && NativeQuackType::T_LAZY === $generator_type->subtype->code) {
-            throw new ScopeError([
-                'message' => "Undeducible subtype `{$generator_type->subtype}' of `{$generator_type}'"
-            ]);
+        if ($generator_type->isList() && $generator_type->subtype->isLazy()) {
+            throw new TypeError(Localization::message('TYP270', [$generator_type->subtype, $generator_type]));
         }
 
         // When the element has no deducible subtype (map)
-        if (is_array($generator_type->subtype) && in_array(NativeQuackType::T_LAZY, [
-            $generator_type->subtype['key']->code,
-            $generator_type->subtype['value']->code
-        ], true)) {
-            throw new ScopeError([
-                'message' => "Undeducible `Map' subtype in `{$generator_type}'"
-            ]);
+        if (is_array($generator_type->subtype)
+            && ($generator_type->subtype['key']->isLazy() || $generator_type->subtype['value']->isLazy())) {
+            throw new ScopeError(Localization::message('TYP280', [$generator_type]));
         }
 
         if (null !== $this->key) {

--- a/src/ast/stmt/ImplStmt.php
+++ b/src/ast/stmt/ImplStmt.php
@@ -21,6 +21,7 @@
  */
 namespace QuackCompiler\Ast\Stmt;
 
+use \QuackCompiler\Intl\Localization;
 use \QuackCompiler\Lexer\Tag;
 use \QuackCompiler\Parser\Parser;
 use \QuackCompiler\Scope\Kind;
@@ -73,30 +74,22 @@ class ImplStmt extends Stmt
         // Try to locate the class/shape
         $unqualified_first = $this->formatQualifiedName($this->class_or_shape);
         $first = $parent_scope->lookup($unqualified_first);
-        $type = Tag::T_CLASS === $this->type
-            ? 'class'
-            : 'shape';
 
         if (null === $first) {
-            throw new ScopeError([
-                'message' => ucfirst($type) . " `{$unqualified_first}' not found"
-            ]);
+            $kind = Tag::T_CLASS === $this->type ? 'Class' : 'Shape';
+            throw new ScopeError(Localization::message('SCO190', [$kind, $unqualified_first]));
         }
 
         // Check type for the symbols
-        if ('shape' === $type) {
+        if (Tag::T_SHAPE === $this->type) {
             // When it is not a shape
             if (~$first & Kind::K_SHAPE) {
-                throw new ScopeError([
-                    'message' => "`{$unqualified_first}' is not a shape"
-                ]);
+                throw new ScopeError(Localization::message('SCO220', [$unqualified_first]));
             }
         } else {
             // Continue, assert this is a class and locate the shape
             if (~$first & Kind::K_CLASS) {
-                throw new ScopeError([
-                    'message' => "`{$unqualified_first}' is not a class"
-                ]);
+                throw new ScopeError(Localization::message('SCO200', [$unqualified_first]));
             }
 
             $shape_name = $this->formatQualifiedName($this->class_for);
@@ -104,16 +97,12 @@ class ImplStmt extends Stmt
 
             // Shape not declared
             if (null === $shape) {
-                throw new ScopeError([
-                    'message' => "Shape `{$shape_name}' not found"
-                ]);
+                throw new ScopeError(Localization::message('SCO210', [$shape_name]));
             }
 
             // Not a shape
             if (~$shape & Kind::K_SHAPE) {
-                throw new ScopeError([
-                    'message' => "`{$shape_name}' is not a shape"
-                ]);
+                throw new ScopeError(Localization::message('SCO220', [$shape_name]));
             }
         }
 

--- a/src/ast/stmt/ShapeStmt.php
+++ b/src/ast/stmt/ShapeStmt.php
@@ -21,6 +21,7 @@
  */
 namespace QuackCompiler\Ast\Stmt;
 
+use \QuackCompiler\Intl\Localization;
 use \QuackCompiler\Parser\Parser;
 
 use \QuackCompiler\Scope\ScopeError;
@@ -65,9 +66,7 @@ class ShapeStmt extends Stmt
 
         foreach ($this->members as $member) {
             if ($this->scope->hasLocal($member)) {
-                throw new ScopeError([
-                    'message' => "Duplicated entry `{$member}' for shape {$this->name}"
-                ]);
+                throw new ScopeError(Localization::message('SCO110', [$member, $this->name]));
             }
 
             // TODO: use bitmask for this, not a pure zend_object
@@ -77,5 +76,9 @@ class ShapeStmt extends Stmt
                 'mutable'     => false
             ]);
         }
+    }
+
+    public function runTypeChecker() {
+        // TODO: Implement type checking for shape
     }
 }

--- a/src/ast/stmt/ShapeStmt.php
+++ b/src/ast/stmt/ShapeStmt.php
@@ -23,8 +23,8 @@ namespace QuackCompiler\Ast\Stmt;
 
 use \QuackCompiler\Intl\Localization;
 use \QuackCompiler\Parser\Parser;
-
 use \QuackCompiler\Scope\ScopeError;
+use \QuackCompiler\Scope\Kind;
 
 class ShapeStmt extends Stmt
 {
@@ -69,12 +69,7 @@ class ShapeStmt extends Stmt
                 throw new ScopeError(Localization::message('SCO110', [$member, $this->name]));
             }
 
-            // TODO: use bitmask for this, not a pure zend_object
-            $this->scope->insert($member, [
-                'initialized' => true,
-                'type'        => 'member_property',
-                'mutable'     => false
-            ]);
+            $this->scope->insert($member, Kind::K_INITIALIZED | Kind::K_MEMBER);
         }
     }
 

--- a/src/intl/locales/en-US.json
+++ b/src/intl/locales/en-US.json
@@ -1,4 +1,22 @@
 {
+    "SCO010": "Duplicated parameter `%s' in anonymous function",
+    "SCO020": "Use of undefined variable `%s'",
+    "SCO030": "Cannot find shape `%s'",
+    "SCO040": "Cannot create instance of `%s' because it is not a shape",
+    "SCO050": "Duplicated object property `%s'",
+    "SCO060": "Duplicated parameter `%s' in function `%s'",
+    "SCO070": "Symbol `%s' is not a variable",
+    "SCO080": "Symbol `%s' is immutable",
+    "SCO090": "Invalid left-hand side in assignment",
+    "SCO100": "Array destructuring expects all children to be names",
+    "SCO110": "Duplicated entry `%s' for shape `%s'",
+    "SCO120": "Duplicated declaration of `%s' on where clause",
+    "SCO130": "Symbol `%s' for %s declared twice",
+    "SCO140": "Called %s outside a loop",
+    "SCO150": "Called %s with undefined label `%s'",
+    "SCO160": "Called %s with invalid label `%s'",
+    "SCO170": "Duplicated declaration of `%s' for enum `%s'",
+    "SCO180": "Same variable name `%s' for key and value on foreach",
     "TYP010": "Value passed to while loop should be a `boolean', not a `%s'",
     "TYP020": "Cannot add element of type `%s' to array of type `%s'",
     "TYP030": "The type of post conditional statement should be a `boolean', not a `%s'",
@@ -23,5 +41,6 @@
     "TYP220": "Expected a `number' on operand `%s' of range expression. Got `%s'",
     "TYP230": "No type overload for operator `%s' on type `%s'",
     "TYP240": "Condition of ternary operator should de `boolean'. Got `%s'",
-    "TYP250": "Both sides of ternary expression must have the same type. Got `%s' and `%s'"
+    "TYP250": "Both sides of ternary expression must have the same type. Got `%s' and `%s'",
+    "TYP260": "`%s' is not iterable"
 }

--- a/src/intl/locales/en-US.json
+++ b/src/intl/locales/en-US.json
@@ -17,6 +17,10 @@
     "SCO160": "Called %s with invalid label `%s'",
     "SCO170": "Duplicated declaration of `%s' for enum `%s'",
     "SCO180": "Same variable name `%s' for key and value on foreach",
+    "SCO190": "%s `%s' not found in implementation",
+    "SCO200": "`%s' is not a class in implementation",
+    "SCO210": "Reference to undeclared shape `%s' in implementation",
+    "SCO220": "Name `%s' is not a shape in implementation",
     "TYP010": "Value passed to while loop should be a `boolean', not a `%s'",
     "TYP020": "Cannot add element of type `%s' to array of type `%s'",
     "TYP030": "The type of post conditional statement should be a `boolean', not a `%s'",
@@ -42,5 +46,7 @@
     "TYP230": "No type overload for operator `%s' on type `%s'",
     "TYP240": "Condition of ternary operator should de `boolean'. Got `%s'",
     "TYP250": "Both sides of ternary expression must have the same type. Got `%s' and `%s'",
-    "TYP260": "`%s' is not iterable"
+    "TYP260": "`%s' is not iterable",
+    "TYP270": "Undeducible subtype `%s' of `%s' in foreach",
+    "TYP280": "Undeducible map subtype in `%s' in foreach"
 }

--- a/src/parser/Grammar.php
+++ b/src/parser/Grammar.php
@@ -242,7 +242,7 @@ class Grammar
         if ($this->parser->is(Tag::T_IDENT)) {
             $alias = $this->identifier();
 
-            if ($this->parser->consumeIf('->')) {
+            if ($this->parser->consumeIf(':')) {
                 $key = $alias;
 
                 $by_reference = $this->parser->consumeIf('*');

--- a/src/scope/Kind.php
+++ b/src/scope/Kind.php
@@ -24,21 +24,19 @@ namespace QuackCompiler\Scope;
 class Kind
 {
     // Base flags
-    const K_FUNCTION    = 0x1;
-    const K_VARIABLE    = 0x2;
-    const K_BLUEPRINT   = 0x4;
-    const K_SHAPE       = 0x8;
-    const K_CLASS       = 0x10;
-    const K_ENUM        = 0x20;
+    const K_FUNCTION    = 1 << 0;
+    const K_VARIABLE    = 1 << 1;
+    const K_BLUEPRINT   = 1 << 2;
+    const K_SHAPE       = 1 << 3;
+    const K_CLASS       = 1 << 4;
+    const K_ENUM        = 1 << 5;
 
     // Additional flags
-    const K_MUTABLE     = 0x40;
-    const K_PARAMETER   = 0x80;
-    const K_LABEL       = 0x100;
-    const K_VIRTUAL     = 0x200;
-    const K_EXPORTED    = 0x400;
-    const K_SPECIAL     = 0x800;
-    const K_MEMBER      = 0x1000;
-    const K_INITIALIZED = 0x2000;
-    const K_PUB         = 0x4000;
+    const K_MUTABLE     = 1 << 6;
+    const K_PARAMETER   = 1 << 7;
+    const K_LABEL       = 1 << 8;
+    const K_SPECIAL     = 1 << 9;
+    const K_MEMBER      = 1 << 10;
+    const K_INITIALIZED = 1 << 11;
+    const K_PUB         = 1 << 12;
 }

--- a/src/scope/ScopeError.php
+++ b/src/scope/ScopeError.php
@@ -27,9 +27,9 @@ class ScopeError extends Exception
 {
     protected $message;
 
-    public function __construct($parameters)
+    public function __construct($message)
     {
-        $this->message = $parameters['message'];
+        $this->message = $message;
     }
 
     public function __toString()


### PR DESCRIPTION
This pull-request does:

- Implement localization for all remaining `ScopeError` and `TypeError`
- Change syntax in `foreach` from `foreach x -> y in {}` to `foreach x: y in {}`