### PR TITLE
More Formatting tests and new proposal for atoms

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -124,7 +124,7 @@
   - [x] ContinueStmt
   - [x] ElifStmt
   - [x] EnumStmt
-  - [ ] ExprStmt
+  - [x] ExprStmt
   - [ ] FnStmt
   - [ ] ForeachStmt
   - [ ] ForStmt

--- a/TODO.md
+++ b/TODO.md
@@ -130,8 +130,8 @@
   - [x] ForStmt
   - [x] IfStmt
   - [ ] ImplStmt
-  - [ ] LabelStmt
-  - [ ] LetStmt
+  - [x] LabelStmt
+  - [x] LetStmt
   - [ ] ModuleStmt
   - [ ] OpenStmt
   - [ ] PostConditionalStmt

--- a/TODO.md
+++ b/TODO.md
@@ -129,18 +129,15 @@
   - [x] ForeachStmt
   - [x] ForStmt
   - [x] IfStmt
-  - [ ] ImplStmt
+  - [x] ImplStmt
   - [x] LabelStmt
   - [x] LetStmt
   - [ ] ModuleStmt
   - [ ] OpenStmt
   - [ ] PostConditionalStmt
-  - [ ] ProgramStmt
   - [ ] RaiseStmt
   - [ ] ReturnStmt
   - [x] ShapeStmt
-  - [ ] Stmt
-  - [ ] StmtList
   - [x] SwitchStmt
   - [ ] TryStmt
   - [x] WhileStmt
@@ -150,7 +147,6 @@
   - [x] BlockExpr
   - [x] BoolExpr
   - [x] CallExpr
-  - [ ] Expr
   - [x] LambdaExpr
   - [x] MapExpr
   - [ ] NameExpr

--- a/TODO.md
+++ b/TODO.md
@@ -125,7 +125,7 @@
   - [x] ElifStmt
   - [x] EnumStmt
   - [x] ExprStmt
-  - [ ] FnStmt
+  - [x] FnStmt
   - [ ] ForeachStmt
   - [ ] ForStmt
   - [x] IfStmt

--- a/TODO.md
+++ b/TODO.md
@@ -126,8 +126,8 @@
   - [x] EnumStmt
   - [x] ExprStmt
   - [x] FnStmt
-  - [ ] ForeachStmt
-  - [ ] ForStmt
+  - [x] ForeachStmt
+  - [x] ForStmt
   - [x] IfStmt
   - [ ] ImplStmt
   - [ ] LabelStmt
@@ -143,7 +143,7 @@
   - [ ] StmtList
   - [x] SwitchStmt
   - [ ] TryStmt
-  - [ ] WhileStmt
+  - [x] WhileStmt
   - [x] AccessExpr
   - [x] ArrayExpr
   - [x] AtomExpr

--- a/src/lexer/Tokenizer.php
+++ b/src/lexer/Tokenizer.php
@@ -50,7 +50,7 @@ class Tokenizer extends Lexer
                 continue;
             }
 
-            if ($this->matches(':') && (ctype_alpha($this->preview()) || '_' === $this->preview())) {
+            if ($this->matches('@') && (ctype_alpha($this->preview()) || '_' === $this->preview())) {
                 return $this->atom();
             }
 

--- a/tests/expr/atom_expr.qtest
+++ b/tests/expr/atom_expr.qtest
@@ -1,11 +1,11 @@
 %%describe
 Supports atoms as expressions
 %%source
-do :foo do :bar do :_ do :baz
-do :atom
+do @foo do @bar do @_ do @baz
+do @atom
 %%expect
-do :foo
-do :bar
-do :_
-do :baz
-do :atom
+do @foo
+do @bar
+do @_
+do @baz
+do @atom

--- a/tests/stmt/elif_stmt.qtest
+++ b/tests/stmt/elif_stmt.qtest
@@ -5,10 +5,11 @@ if 1 > 0 do console.writeline("One is greater than zero") elif true {-do nothing
 
 [ firstLabel ]
 for i from 1 to 10 by 2
+[ secondLabel]
   for j from 1 to 10
-    if (i = 3) and (j =~ 0)
+    if (i = 3) and (j <> 0)
       break firstLabel
-    elif (i =~ 2)
+    elif (i <> 2)
       continue firstLabel
     end
   end
@@ -20,10 +21,11 @@ elif true
 end
 [firstLabel]
 for i from 1 to 10 by 2
+  [secondLabel]
   for j from 1 to 10
-    if (i = 3) and (j =~ 0)
+    if (i = 3) and (j <> 0)
       break firstLabel
-    elif (i =~ 2)
+    elif (i <> 2)
       continue firstLabel
     end
   end

--- a/tests/stmt/expr_stmt.qtest
+++ b/tests/stmt/expr_stmt.qtest
@@ -1,0 +1,11 @@
+%%describe
+Supports formatting expr statements
+%%source
+do true, false, console.write("Something"), 1 + 1
+do x :- 0
+%%expect
+do true
+ , false
+ , console.write("Something")
+ , 1 + 1
+do x :- 0

--- a/tests/stmt/expr_stmt.qtest
+++ b/tests/stmt/expr_stmt.qtest
@@ -2,10 +2,12 @@
 Supports formatting expr statements
 %%source
 do true, false, console.write("Something"), 1 + 1
-do x :- 0
+do "Hello " + "World"
+do "Quack"
 %%expect
 do true
  , false
  , console.write("Something")
  , 1 + 1
-do x :- 0
+do "Hello " + "World"
+do "Quack"

--- a/tests/stmt/fn_stmt.qtest
+++ b/tests/stmt/fn_stmt.qtest
@@ -1,0 +1,40 @@
+%%describe
+Supports formatting fn statements
+%%source
+fn quack() :- console.write ("Quack Quack!")
+
+pub fn fib(n)
+  if n = 0 or n = 1
+    ^ n
+  else
+    ^ fib(n-1) + fib(n-2)
+  end
+end
+
+fn fact (n)
+  let fact :- 1
+  for i from 1 to n do fact :- fact * i end
+  ^ fact
+end
+
+fn fact (n)
+  ^ n = 0 then 1 else n * fact( n - 1 )
+end
+%%expect
+fn quack() :- console.write("Quack Quack!")
+pub fn fib(n)
+  if n = 0 or n = 1 ^ n
+  else
+    ^ fib(n - 1) + fib(n - 2)
+  end
+end
+fn fact(n)
+  let fact :- 1
+  for i from 1 to n
+    do fact :- fact * i
+  end
+  ^ fact
+end
+fn fact(n)
+  ^ n = 0 then 1 else n * fact(n - 1)
+end

--- a/tests/stmt/for_stmt.qtest
+++ b/tests/stmt/for_stmt.qtest
@@ -1,0 +1,17 @@
+%%describe
+Supports formatting for statements
+%%source
+let fact :- 1, n :- 10
+for i from 1 to n do fact :- fact * i end
+for j from -2 to 8 by 2
+  continue
+end
+%%expect
+let fact :- 1
+  , n :- 10
+for i from 1 to n
+  do fact :- fact * i
+end
+for j from -2 to 8 by 2
+  continue
+end

--- a/tests/stmt/foreach_stmt.qtest
+++ b/tests/stmt/foreach_stmt.qtest
@@ -3,7 +3,7 @@ Supports formatting foreach statements
 %%source
 foreach item in {1, 2, 3} do console.write("Number: " + item) end
 let dict :- #{"key1" : "String 1", "key2" : "String 2"}
-foreach key : value in dict
+foreach key:value in dict
   do console.write("Key: " + key + " Value: " + value)
 end
 %%expect

--- a/tests/stmt/foreach_stmt.qtest
+++ b/tests/stmt/foreach_stmt.qtest
@@ -1,0 +1,16 @@
+%%describe
+Supports formatting foreach statements
+%%source
+foreach item in {1, 2, 3} do console.write("Number: " + item) end
+let dict :- #{"key1" : "String 1", "key2" : "String 2"}
+foreach key : value in dict
+  do console.write("Key: " + key + " Value: " + value)
+end
+%%expect
+foreach item in { 1, 2, 3 }
+  do console.write("Number: " + item)
+end
+let dict :- #{ "key1": "String 1", "key2": "String 2" }
+foreach key: value in dict
+  do console.write("Key: " + key + " Value: " + value)
+end

--- a/tests/stmt/if_stmt.qtest
+++ b/tests/stmt/if_stmt.qtest
@@ -2,14 +2,14 @@
 Supports formatting if statements
 %%source
 if 1 > 0 do console.writeline("I am the only one here") end
-let x:- 10 if x =~ 2 do console.write("X is not equal to two")
+let x:- 10 if x <> 2 do console.write("X is not equal to two")
            else do console.write("X is equal to two") end
 %%expect
 if 1 > 0
   do console.writeline("I am the only one here")
 end
 let x :- 10
-if x =~ 2
+if x <> 2
   do console.write("X is not equal to two")
 else
   do console.write("X is equal to two")

--- a/tests/stmt/impl_stmt.qtest
+++ b/tests/stmt/impl_stmt.qtest
@@ -1,0 +1,31 @@
+%%describe
+Supports formatting impl statements
+%%source
+shape Point x y end
+impl Point
+  add() ^ self.x + self.y end
+end
+class Human
+  say(what)
+end
+impl Humanize for Human
+  say(what) do console.write(what) end
+end
+%%expect
+shape Point
+  x
+  y
+end
+impl Point
+  add()
+    ^ self.x + self.y
+  end
+end
+class Human
+  say(what)
+end
+impl Humanize for Human
+  say(what)
+    do console.write(what)
+  end
+end

--- a/tests/stmt/label_stmt.qtest
+++ b/tests/stmt/label_stmt.qtest
@@ -1,0 +1,30 @@
+%%describe
+Supports formatting label statements
+%%source
+[first]
+let allowed :- true
+[second]
+if allowed
+  let x :- 10
+  [third]
+  for i from 1 to x
+    do allowed :- false
+    continue second {- would be inf loop if allowed = true -}
+  end
+else
+  continue third {- send it back to the for loop -}
+end
+%%expect
+[first]
+let allowed :- true
+[second]
+if allowed
+  let x :- 10
+  [third]
+  for i from 1 to x
+    do allowed :- false
+    continue second
+  end
+else
+  continue third
+end

--- a/tests/stmt/let_stmt.qtest
+++ b/tests/stmt/let_stmt.qtest
@@ -1,0 +1,9 @@
+%%describe
+Supports formatting let statements
+%%source
+let greeting :- "Hello World!"
+let x :- 1, y :- 2
+%%expect
+let greeting :- "Hello World!"
+let x :- 1
+  , y :- 2

--- a/tests/stmt/while_stmt.qtest
+++ b/tests/stmt/while_stmt.qtest
@@ -1,0 +1,22 @@
+%%describe
+Supports formatting while statements
+%%source
+[myLabel]
+while true break myLabel end
+while true break end
+let x :- 0
+while ++x < 10
+  do console.write("X is: " + x)
+end
+%%expect
+[myLabel]
+while true
+  break myLabel
+end
+while true
+  break
+end
+let x :- 0
+while ++x < 10
+  do console.write("X is: " + x)
+end


### PR DESCRIPTION
This PR has the formatting tests for:
- `ExprStmt`
- `FnStmt`
- `ForeachStmt`
- `ForStmt`
- `ImplStmt`
- `LabelStmt`
- `LetSmt`.

It also proposes that we change our `atoms` from `:atom` to `@atom` as per #98 