### PR TITLE
Interpret quack with shebang

### DIFF
--- a/src/Quack.php
+++ b/src/Quack.php
@@ -21,8 +21,7 @@
  */
 namespace QuackCompiler;
 
-define('BASE_PATH', './src/');
-require_once './src/toolkit/QuackToolkit.php';
+require_once dirname(__FILE__) . '/toolkit/QuackToolkit.php';
 
 use \Exception;
 use \QuackCompiler\Lexer\Tag;

--- a/src/Quack.php
+++ b/src/Quack.php
@@ -57,8 +57,15 @@ class Quack
                 $lexer = new Tokenizer(file_get_contents($file));
                 $parser = new TokenReader($lexer);
                 $parser->parse();
-                $parser->ast->injectScope($global_scope);
-                $parser->ast->runTypeChecker();
+
+                if (!$this->inArguments('--disable-scope')) {
+                    $parser->ast->injectScope($global_scope);
+                }
+
+                if (!$this->inArguments('--disable-typechecker')) {
+                    $parser->ast->runTypeChecker();
+                }
+
                 echo $parser->format();
             });
         } catch (Exception $e) {

--- a/src/lexer/Tokenizer.php
+++ b/src/lexer/Tokenizer.php
@@ -54,7 +54,7 @@ class Tokenizer extends Lexer
                 return $this->atom();
             }
 
-            if ($this->matches('--')) {
+            if ($this->matches('--') || $this->matches('#!')) {
                 $this->singlelineComment();
                 continue;
             }

--- a/src/toolkit/QuackToolkit.php
+++ b/src/toolkit/QuackToolkit.php
@@ -29,7 +29,7 @@ define('INTL', 'intl');
 
 function import($module, $file)
 {
-    require_once BASE_PATH . '/' . $module . '/' . $file . '.php';
+    require_once dirname(__FILE__) . '/../' . $module . '/' . $file . '.php';
 }
 
 /* Internationalization */

--- a/tools/testsuite/run-tests.hy
+++ b/tools/testsuite/run-tests.hy
@@ -118,7 +118,7 @@
      :expect (joiner expect)
      :command
       (if (empty? command)
-        "php ./src/Quack.php %s"
+        "php ./src/Quack.php %s --disable-typechecker --disable-scope"
         (joiner command)) }))
 
 (defn create-tmp-folder []


### PR DESCRIPTION
This pull-request implements support for shebang (`#!`)

To run a Quack script on Unix and BSD, you now can create a `.qk` file with:

```ruby
#!/usr/bin/php path/to/Quack.php

do 'Your Quack source here'
```

Give permission of execution to the file with `sudo chmod +x filename.qk` and run with `./filename.qk`.