### PR TITLE
All tests done (but OpenStmt)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -136,7 +136,7 @@
   - [ ] OpenStmt
   - [x] PostConditionalStmt
   - [x] RaiseStmt
-  - [ ] ReturnStmt
+  - [x] ReturnStmt
   - [x] ShapeStmt
   - [x] SwitchStmt
   - [ ] TryStmt

--- a/TODO.md
+++ b/TODO.md
@@ -134,7 +134,7 @@
   - [x] LetStmt
   - [x] ModuleStmt
   - [ ] OpenStmt
-  - [ ] PostConditionalStmt
+  - [x] PostConditionalStmt
   - [ ] RaiseStmt
   - [ ] ReturnStmt
   - [x] ShapeStmt

--- a/TODO.md
+++ b/TODO.md
@@ -156,11 +156,11 @@
   - [x] ObjectExpr
   - [x] OperatorExpr
   - [x] PartialFuncExpr
-  - [ ] PostfixExpr
-  - [ ] PrefixExpr
+  - [x] PostfixExpr
+  - [x] PrefixExpr
   - [x] RangeExpr
-  - [ ] RegexExpr
-  - [ ] StringExpr
-  - [ ] TernaryExpr
-  - [ ] WhenExpr
+  - [x] RegexExpr
+  - [x] StringExpr
+  - [x] TernaryExpr
+  - [x] WhenExpr
   - [ ] WhereExpr

--- a/TODO.md
+++ b/TODO.md
@@ -163,4 +163,4 @@
   - [x] StringExpr
   - [x] TernaryExpr
   - [x] WhenExpr
-  - [ ] WhereExpr
+  - [x] WhereExpr

--- a/TODO.md
+++ b/TODO.md
@@ -135,7 +135,7 @@
   - [x] ModuleStmt
   - [ ] OpenStmt
   - [x] PostConditionalStmt
-  - [ ] RaiseStmt
+  - [x] RaiseStmt
   - [ ] ReturnStmt
   - [x] ShapeStmt
   - [x] SwitchStmt

--- a/TODO.md
+++ b/TODO.md
@@ -149,10 +149,10 @@
   - [x] CallExpr
   - [x] LambdaExpr
   - [x] MapExpr
-  - [ ] NameExpr
+  - [x] NameExpr
   - [x] NewExpr
   - [x] NilExpr
-  - [ ] NumberExpr
+  - [x] NumberExpr
   - [x] ObjectExpr
   - [x] OperatorExpr
   - [x] PartialFuncExpr

--- a/TODO.md
+++ b/TODO.md
@@ -139,7 +139,7 @@
   - [x] ReturnStmt
   - [x] ShapeStmt
   - [x] SwitchStmt
-  - [ ] TryStmt
+  - [x] TryStmt
   - [x] WhileStmt
   - [x] AccessExpr
   - [x] ArrayExpr

--- a/TODO.md
+++ b/TODO.md
@@ -132,7 +132,7 @@
   - [x] ImplStmt
   - [x] LabelStmt
   - [x] LetStmt
-  - [ ] ModuleStmt
+  - [x] ModuleStmt
   - [ ] OpenStmt
   - [ ] PostConditionalStmt
   - [ ] RaiseStmt

--- a/src/ast/stmt/BreakStmt.php
+++ b/src/ast/stmt/BreakStmt.php
@@ -63,6 +63,13 @@ class BreakStmt extends Stmt
                 throw new ScopeError(Localization::message('SCO140', ['break']));
             }
         } else {
+            $metaLabel = $parent_scope->getMetaInContext(Meta::M_LABEL);
+
+            // If metaLabel is null, the user is calling 'break' outside a loop
+            if (null === $metaLabel) {
+                throw new ScopeError(Localization::message('SCO140', ['break']));
+            }
+
             $label = $parent_scope->lookup($this->label);
 
             // When the symbol doesn't exist

--- a/src/ast/stmt/BreakStmt.php
+++ b/src/ast/stmt/BreakStmt.php
@@ -63,10 +63,10 @@ class BreakStmt extends Stmt
                 throw new ScopeError(Localization::message('SCO140', ['break']));
             }
         } else {
-            $metaLabel = $parent_scope->getMetaInContext(Meta::M_LABEL);
+            $meta_label = $parent_scope->getMetaInContext(Meta::M_LABEL);
 
-            // If metaLabel is null, the user is calling 'break' outside a loop
-            if (null === $metaLabel) {
+            // If meta_label is null, the user is calling 'break' outside a loop
+            if (null === $meta_label) {
                 throw new ScopeError(Localization::message('SCO140', ['break']));
             }
 

--- a/src/ast/stmt/ContinueStmt.php
+++ b/src/ast/stmt/ContinueStmt.php
@@ -63,6 +63,13 @@ class ContinueStmt extends Stmt
                 throw new ScopeError(Localization::message('SCO140', ['continue']));
             }
         } else {
+            $metaLabel = $parent_scope->getMetaInContext(Meta::M_LABEL);
+
+            // If metaLabel is null, the user is calling 'continue' outside a loop
+            if (null === $metaLabel) {
+                throw new ScopeError(Localization::message('SCO140', ['continue']));
+            }
+
             $label = $parent_scope->lookup($this->label);
 
             // When the symbol doesn't exist

--- a/src/ast/stmt/ContinueStmt.php
+++ b/src/ast/stmt/ContinueStmt.php
@@ -63,10 +63,10 @@ class ContinueStmt extends Stmt
                 throw new ScopeError(Localization::message('SCO140', ['continue']));
             }
         } else {
-            $metaLabel = $parent_scope->getMetaInContext(Meta::M_LABEL);
+            $meta_label = $parent_scope->getMetaInContext(Meta::M_LABEL);
 
-            // If metaLabel is null, the user is calling 'continue' outside a loop
-            if (null === $metaLabel) {
+            // If meta_label is null, the user is calling 'continue' outside a loop
+            if (null === $meta_label) {
                 throw new ScopeError(Localization::message('SCO140', ['continue']));
             }
 

--- a/src/ast/stmt/TryStmt.php
+++ b/src/ast/stmt/TryStmt.php
@@ -68,7 +68,7 @@ class TryStmt extends Stmt
 
         if (null !== $this->finally) {
             $source .= $parser->indent();
-            $source .= 'finally ';
+            $source .= 'finally';
             $source .= PHP_EOL;
 
             $parser->openScope();

--- a/tests/expr/name_expr.qtest
+++ b/tests/expr/name_expr.qtest
@@ -1,0 +1,11 @@
+%%describe
+Supports formatting name expressions
+%%source
+let x :- 1 do x let _ :- 'a' do _ let _X_1 :- nil do _X_1
+%%expect
+let x :- 1
+do x
+let _ :- 'a'
+do _
+let _X_1 :- nil
+do _X_1

--- a/tests/expr/number_expr.qtest
+++ b/tests/expr/number_expr.qtest
@@ -1,5 +1,5 @@
 %%describe
-Supports formatting name expressions
+Supports formatting number expressions
 %%source
 do 0b00000001
 do 1 + 1

--- a/tests/expr/number_expr.qtest
+++ b/tests/expr/number_expr.qtest
@@ -1,0 +1,17 @@
+%%describe
+Supports formatting name expressions
+%%source
+do 0b00000001
+do 1 + 1
+do 1/2*3
+do 12e+10 do 13e-2
+do 0o777
+do 0xFFFFBC
+%%expect
+do 0b00000001
+do 1 + 1
+do 1 / 2 * 3
+do 12e+10
+do 13e-2
+do 0o777
+do 0xFFFFBC

--- a/tests/expr/postfix_expr
+++ b/tests/expr/postfix_expr
@@ -1,0 +1,5 @@
+%%describe
+Supports formatting postfix expressions
+%%source
+{- We do not have postfix operators yet -}
+%%expect

--- a/tests/expr/prefix_expr.qtest
+++ b/tests/expr/prefix_expr.qtest
@@ -1,0 +1,24 @@
+%%describe
+Supports formatting prefix expressions
+%%source
+do not true do +1 do -2 do -(-4)
+do ~0
+let y :- %{ name: "Luiz" }
+let x :- ^^y
+
+fn write(*var)
+  do console.write(*var)
+end
+%%expect
+do not true
+do +1
+do -2
+do -(-4)
+do ~0
+let y :- %{
+  name: "Luiz"
+}
+let x :- ^^y
+fn write(*var)
+  do console.write(*var)
+end

--- a/tests/expr/regex_expr.qtest
+++ b/tests/expr/regex_expr.qtest
@@ -1,0 +1,10 @@
+%%describe
+Supports formatting regex expressions
+%%source
+do &/^foo/
+do &/^#(?:[0-9a-fA-F]{3}){1,2}/i
+do &/&(amp;)\/[^\/]*\/([\\S]?)*/
+%%expect
+do &/^foo/
+do &/^#(?:[0-9a-fA-F]{3}){1,2}/i
+do &/&(amp;)\/[^\/]*\/([\\S]?)*/

--- a/tests/expr/string_expr.qtest
+++ b/tests/expr/string_expr.qtest
@@ -1,0 +1,8 @@
+%%describe
+Supports formatting string expressions
+%%source
+do "My Cool String"
+do 'other one'
+%%expect
+do "My Cool String"
+do 'other one'

--- a/tests/expr/ternary_expr.qtest
+++ b/tests/expr/ternary_expr.qtest
@@ -1,0 +1,6 @@
+%%describe
+Supports formatting ternary expressions
+%%source
+do true then console.write("Passed") else console.error("Unexpected error happened")
+%%expect
+do true then console.write("Passed") else console.error("Unexpected error happened")

--- a/tests/expr/when_expr.qtest
+++ b/tests/expr/when_expr.qtest
@@ -1,0 +1,18 @@
+%%describe
+Supports formatting when expressions
+%%source
+fn mySwitch(what)
+  ^ when
+         | what = "Luiz"      -> "Turing Tape!";
+       | what = "Marcelo" -> "Lambda Calculus!";
+     | else ""
+    end
+end
+%%expect
+fn mySwitch(what)
+  ^ when
+    | what = "Luiz" -> "Turing Tape!";
+    | what = "Marcelo" -> "Lambda Calculus!";
+    | else ""
+  end
+end

--- a/tests/expr/where_expr.qtest
+++ b/tests/expr/where_expr.qtest
@@ -1,0 +1,8 @@
+%%describe
+Supports formatting where expressions
+%%source
+let add :- &[a, b] -> a + b where a :- 1; b :- 2
+%%expect
+let add :- &[a, b] -> a + b
+  where a :- 1
+      ; b :- 2

--- a/tests/stmt/label_stmt.qtest
+++ b/tests/stmt/label_stmt.qtest
@@ -2,29 +2,15 @@
 Supports formatting label statements
 %%source
 [first]
-let allowed :- true
+let x :- 10
 [second]
-if allowed
-  let x :- 10
-  [third]
-  for i from 1 to x
-    do allowed :- false
-    continue second {- would be inf loop if allowed = true -}
-  end
-else
-  continue third {- send it back to the for loop -}
+for i from 1 to x
+  continue second
 end
 %%expect
 [first]
-let allowed :- true
+let x :- 10
 [second]
-if allowed
-  let x :- 10
-  [third]
-  for i from 1 to x
-    do allowed :- false
-    continue second
-  end
-else
-  continue third
+for i from 1 to x
+  continue second
 end

--- a/tests/stmt/module_stmt.qtest
+++ b/tests/stmt/module_stmt.qtest
@@ -1,0 +1,12 @@
+%%describe
+Supports formatting module statements
+%%source
+module Quack.Core.Math
+const pi :- 3.14
+fn add(x, y) :- x + y
+fn sub(x, y) :- add(x, -y)
+%%expect
+module Quack.Core.Math
+const pi :- 3.14
+fn add(x, y) :- x + y
+fn sub(x, y) :- add(x, -y)

--- a/tests/stmt/post_conditional_stmt.qtest
+++ b/tests/stmt/post_conditional_stmt.qtest
@@ -1,0 +1,15 @@
+%%describe
+Supports formatting post conditional statements
+%%source
+fn test(n)
+ ^ n unless n = 0
+end
+
+let jaca :- true
+do console.write("Jaca is true") when jaca
+%%expect
+fn test(n)
+  ^ n unless n = 0
+end
+let jaca :- true
+do console.write("Jaca is true") when jaca

--- a/tests/stmt/raise_stmt.qtest
+++ b/tests/stmt/raise_stmt.qtest
@@ -1,0 +1,27 @@
+%%describe
+Supports formatting raise statements
+%%source
+shape Exception
+  desc
+end
+
+impl Exception
+  show() :- self.desc
+end
+
+let me :- %{ name: "Luiz", age: 27 }
+raise %Exception %{ desc: "Name is empty"} unless me.name = ""
+%%expect
+shape Exception
+  desc
+end
+impl Exception
+  show() :- self.desc
+end
+let me :- %{
+  name: "Luiz",
+  age: 27
+}
+raise %Exception %{
+  desc: "Name is empty"
+} unless me.name = ""

--- a/tests/stmt/return_stmt.qtest
+++ b/tests/stmt/return_stmt.qtest
@@ -1,0 +1,31 @@
+%%describe
+Supports formatting return statements
+%%source
+fn doubleN(x)
+  ^ &(* 2)(x)
+end
+let null :- &[a, b] -> b
+fn retSmth(smth)
+  ^ smth <> null then smth else null
+end
+fn recursive(n)
+  if n < 1
+    ^ 0
+  else
+    ^ n + recursive(n - 1)
+  end
+end
+%%expect
+fn doubleN(x)
+  ^ &(* 2)(x)
+end
+let null :- &[a, b] -> b
+fn retSmth(smth)
+  ^ smth <> null then smth else null
+end
+fn recursive(n)
+  if n < 1 ^ 0
+  else
+    ^ n + recursive(n - 1)
+  end
+end

--- a/tests/stmt/return_stmt.qtest
+++ b/tests/stmt/return_stmt.qtest
@@ -4,9 +4,8 @@ Supports formatting return statements
 fn doubleN(x)
   ^ &(* 2)(x)
 end
-let null :- &[a, b] -> b
 fn retSmth(smth)
-  ^ smth <> null then smth else null
+  ^ smth <> nil then smth else nil
 end
 fn recursive(n)
   if n < 1
@@ -19,9 +18,8 @@ end
 fn doubleN(x)
   ^ &(* 2)(x)
 end
-let null :- &[a, b] -> b
 fn retSmth(smth)
-  ^ smth <> null then smth else null
+  ^ smth <> nil then smth else nil
 end
 fn recursive(n)
   if n < 1 ^ 0

--- a/tests/stmt/try_stmt.qtest
+++ b/tests/stmt/try_stmt.qtest
@@ -1,0 +1,54 @@
+%%describe
+Supports formatting try statements
+%%source
+shape HTTPRequest
+  url
+  method
+  status
+  responseText
+end
+impl HttpRequest
+  openConn()
+    -- simulate an error
+    do self.status :- 404
+    raise 'Page not found!'
+  end
+
+  closeConn()
+  end
+
+  load()
+    try
+      do self.openConn(), console.write(self.responseText)
+    rescue (Exception e)
+      do console.error(e)
+    finally
+      do self.closeConn()
+    end
+  end
+end
+%%expect
+shape HTTPRequest
+  url
+  method
+  status
+  responseText
+end
+impl HttpRequest
+  openConn()
+    do self.status :- 404
+    raise 'Page not found!'
+  end
+  closeConn()
+  end
+  load()
+    try
+      do self.openConn()
+       , console.write(self.responseText)
+    rescue (Exception e)
+      do console.error(e)
+    finally
+      do self.closeConn()
+    end
+  end
+end

--- a/tests/stmt/while_stmt.qtest
+++ b/tests/stmt/while_stmt.qtest
@@ -5,7 +5,7 @@ Supports formatting while statements
 while true break myLabel end
 while true break end
 let x :- 0
-let succ :- &[m] -> m+1
+let succ :- &[m] -> &(+ 1)(m)
 while x < 10
   do x :- succ(x)
   do console.write("X is: " + x)
@@ -19,7 +19,7 @@ while true
   break
 end
 let x :- 0
-let succ :- &[m] -> m + 1
+let succ :- &[m] -> &(+ 1)(m)
 while x < 10
   do x :- succ(x)
   do console.write("X is: " + x)

--- a/tests/stmt/while_stmt.qtest
+++ b/tests/stmt/while_stmt.qtest
@@ -5,7 +5,9 @@ Supports formatting while statements
 while true break myLabel end
 while true break end
 let x :- 0
-while ++x < 10
+let succ :- &[m] -> m+1
+while x < 10
+  do x :- succ(x)
   do console.write("X is: " + x)
 end
 %%expect
@@ -17,6 +19,8 @@ while true
   break
 end
 let x :- 0
-while ++x < 10
+let succ :- &[m] -> m + 1
+while x < 10
+  do x :- succ(x)
   do console.write("X is: " + x)
 end


### PR DESCRIPTION
This PR implements the formatting tests that were left in `TODO`. They are:

- ModuleStmt
- PostConditionalStmt
- RaiseStmt
- ReturnStmt
- TryStmt
- NameExpr
- NumberExpr
- PostfixExpr _// I only created the file once we do not have this kind of expression yet_
- PrefixExpr
- RegexExpr
- StringExpr
- TernaryExpr

For the tests below, I would like you @haskellcamargo to see if they are compliant with the language, once it is my first time using such expressions:
- WhenExpr
- WhereExpr

I also fixed a small bug for the `ContinueStmt` and `BreakStmt` that would not raise an error with the code below:
```
[label]
for i from 1 to 10
  ...
end
continue label // outside the loop
```

Thank you!