### PR TITLE
Fixing a small bug on numbers

### DIFF
--- a/src/lexer/Tokenizer.php
+++ b/src/lexer/Tokenizer.php
@@ -144,15 +144,18 @@ class Tokenizer extends Lexer
             $buffer = array_merge($buffer, $this->integer());
         }
         // check optional exp state: looking for a 'e', 'e+' or 'e-' and integers
-        if (!$this->isEnd() && $this->is('e') && (
-            $this->preview() === '+' || $this->preview() === '-' ||
-            ctype_digit($this->preview()))) {
-            $tag = Tag::T_DOUBLE_EXP;
-            $buffer[] = $this->readChar(); // append 'e'
-            if ($this->is('+') || $this->is('-')) {
+        if (!$this->isEnd() && $this->is('e')) {
+            if (ctype_digit($this->preview())) {
+              $tag = Tag::T_DOUBLE_EXP;
+              $buffer[] = $this->readChar(); // append 'e'
+              $buffer = array_merge($buffer, $this->integer());
+            } else if (($this->preview() === '+' || $this->preview() === '-')
+              && ctype_digit($this->preview(2))) {
+                $tag = Tag::T_DOUBLE_EXP;
+                $buffer[] = $this->readChar(); // append 'e'
                 $buffer[] = $this->readChar(); // append '+' or '-'
+                $buffer = array_merge($buffer, $this->integer());
             }
-            $buffer = array_merge($buffer, $this->integer());
         }
 
         $value = implode($buffer);


### PR DESCRIPTION
There was a small bug on numbers whose lexer was accepting the format `1.2e` as a valid number.

You will realize that I broke the `if` I changed in two small parts once it was already too big and I needed to add another condition.