### PR TITLE
Modifying WhenExpr

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The language is metaprogrammable and very extensible. You can easily build exten
 #### Hello World
 
 ```ruby
-fn main
+fn main()
   print "Hello World!"
 end
 ```
@@ -44,16 +44,16 @@ end
 #### Factorial
 
 ```ruby
--: imperative
-fn fact [n]
+[imperative]
+fn fact(n)
   let fact :- 1
   for i from 1 to n do fact :- fact * i
   ^ fact
 end
 
--: tail_call_recursion
-fn fact [n]
-  ^ n = 0 then 1 else n * fact[ n - 1 ]
+[tail_call_recursion]
+fn fact(n)
+  ^ n = 0 then 1 else n * fact(n - 1)
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The language is metaprogrammable and very extensible. You can easily build exten
 
 ```ruby
 fn main()
-  print "Hello World!"
+  do print("Hello World!")
 end
 ```
 
@@ -52,9 +52,7 @@ fn fact(n)
 end
 
 [tail_call_recursion]
-fn fact(n)
-  ^ n = 0 then 1 else n * fact(n - 1)
-end
+fn fact(n) :- n = 0 then 1 else n * fact(n - 1)
 ```
 
 ### How does it work?

--- a/TODO.md
+++ b/TODO.md
@@ -166,6 +166,7 @@
 
 # Bug fixes and tasks left on AST
 
+  - [x] Fix example on README file
   - [x] Change WhenExpr separators from `|` and `;` to `,`
   - [ ] Create ImportStmt (like ES6)
   - [ ] Make ModuleStmt the first statement of a file.

--- a/TODO.md
+++ b/TODO.md
@@ -133,7 +133,6 @@
   - [x] LabelStmt
   - [x] LetStmt
   - [x] ModuleStmt
-  - [ ] OpenStmt
   - [x] PostConditionalStmt
   - [x] RaiseStmt
   - [x] ReturnStmt
@@ -164,3 +163,11 @@
   - [x] TernaryExpr
   - [x] WhenExpr
   - [x] WhereExpr
+
+# Bug fixes and tasks left on AST
+
+  - [x] Change WhenExpr separators from `|` and `;` to `,`
+  - [ ] Create ImportStmt (like ES6)
+  - [ ] Make ModuleStmt the first statement of a file.
+  - [ ] Check and fix ImplStmt
+  - [ ] Fix WhereExpr and change from `;` to `,`

--- a/src/ast/expr/WhenExpr.php
+++ b/src/ast/expr/WhenExpr.php
@@ -47,7 +47,6 @@ class WhenExpr extends Expr
             $obj = $this->cases[$i];
 
             $source .= $parser->indent();
-            $source .= '| ';
 
             if (null !== $obj->condition) {
                 $source .= $obj->condition->format($parser);
@@ -59,7 +58,7 @@ class WhenExpr extends Expr
             $source .= $obj->action->format($parser);
 
             if ($i + 1 !== $l) {
-                $source .= ';';
+                $source .= ',';
                 $source .= PHP_EOL;
             }
         }

--- a/tests/expr/when_expr.qtest
+++ b/tests/expr/when_expr.qtest
@@ -3,16 +3,23 @@ Supports formatting when expressions
 %%source
 fn mySwitch(what :: string)
   ^ when
-         | what = "Luiz"      -> "Turing Tape!";
-       | what = "Marcelo" -> "Lambda Calculus!";
-     | else ""
+          what = "Luiz"      -> "Turing Tape!",
+        what = "Marcelo" -> "Lambda Calculus!",
+      else "No matches"
     end
 end
+
+let x :- 1
+do when x = 1 -> 1 end
 %%expect
 fn mySwitch(what)
   ^ when
-    | what = "Luiz" -> "Turing Tape!";
-    | what = "Marcelo" -> "Lambda Calculus!";
-    | else ""
+    what = "Luiz" -> "Turing Tape!",
+    what = "Marcelo" -> "Lambda Calculus!",
+    else "No matches"
   end
+end
+let x :- 1
+do when
+  x = 1 -> 1
 end


### PR DESCRIPTION
This PR proposes the change of the `WhenExpr` in order to keep Quack's new patterns.

Before:

```F#
when
  | x = 1 -> "One";
  | x = 2 -> "Two";
  | else "None"
end
```

Now:
```F#
when
  x = 1 -> "One",
  x = 2 -> "Two",
  else "None"
end
```

It also fixes the examples on the README file.
