### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-
 FROM php:7.1-alpine
+
+LABEL maintainer="paulo.cuchi@gmail.com"
 
 RUN apk add tini --update
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+
+FROM php:7.1-alpine
+
+RUN apk add tini --update
+
+COPY src /usr/share/quack
+
+RUN echo "php /usr/share/quack/Quack.php \$@" > /bin/quack \
+    && chmod +x /bin/quack
+
+CMD ["tini", "--", "php", "/usr/share/quack/repl/QuackRepl.php"]
+


### PR DESCRIPTION
This file generates a docker image bundled with Alpine Linux and PHP 7.1, which sums up to ~57MB.

By default it start the REPL mode, but it can be used to build other images using the `quack` executable.