### PR TITLE
Using HHVM in the docker image :rocket:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
-FROM php:7.1-alpine
+FROM hhvm/hhvm:3.22.1
 
 LABEL maintainer="paulo.cuchi@gmail.com"
 
-RUN apk add tini --update
-
 COPY src /usr/share/quack
 
-RUN echo "php /usr/share/quack/Quack.php \$@" > /bin/quack \
+RUN echo "hhvm /usr/share/quack/Main.php \$@" > /bin/quack \
     && chmod +x /bin/quack
 
-CMD ["tini", "--", "php", "/usr/share/quack/repl/QuackRepl.php"]
+CMD ["hhvm", "/usr/share/quack/Main.php"]
 

--- a/src/cli/Console.php
+++ b/src/cli/Console.php
@@ -82,7 +82,7 @@ class Console
 
     public function sttySaveCheckpoint()
     {
-        return $this->stty_settings = preg_replace('#.*; ?#s', '', $this->stty('--all'));
+        return $this->stty_settings = preg_replace('#.*; ?#s', '', $this->stty('-a'));
     }
 
     public function sttyRestoreCheckpoint()


### PR DESCRIPTION
The old alpine image doesn't handle the `stty` very well, and hack is cooler anyway :sunglasses: 

Also, using `-a` on the `stty`, because @haskellcamargo told me it would be more compatible with other systems :heart: 