### PR TITLE
Replaced all instances of 'sizeof' to 'count', per deprecation standa…

### DIFF
--- a/build.php
+++ b/build.php
@@ -42,7 +42,7 @@ function minify($source, $pure_identifiers)
 
     $index = 0;
     $tokens = token_get_all($source);
-    $length = sizeof($tokens);
+    $length = count($tokens);
     $result = '';
     $namespace = '';
     $use = [];
@@ -365,7 +365,7 @@ function getCroakBuffer()
 
     // Binary optimization
     $index = 0;
-    $length = sizeof($byte_array);
+    $length = count($byte_array);
     $compressed_byte_array = [];
     while ($index < $length) {
         if (0 === $byte_array[$index]) {

--- a/src/Main.php
+++ b/src/Main.php
@@ -32,7 +32,7 @@ use \QuackCompiler\Parser\TokenReader;
 use \QuackCompiler\Scope\Scope;
 
 // Compile file instead of opening interactive mode
-if (sizeof($argv) > 1) {
+if (count($argv) > 1) {
     $disable_typechecker = in_array('--disable-typechecker', $argv, true);
     $disable_scope = in_array('--disable-scope', $argv, true);
 

--- a/src/ast/expr/ArrayExpr.php
+++ b/src/ast/expr/ArrayExpr.php
@@ -41,7 +41,7 @@ class ArrayExpr extends Expr
     public function format(Parser $parser)
     {
         $source = '{';
-        if (sizeof($this->items) > 0) {
+        if (count($this->items) > 0) {
             $source .= ' ';
             $source .= implode(', ', array_map(function($item) use ($parser) {
                 return $item->format($parser);
@@ -63,7 +63,7 @@ class ArrayExpr extends Expr
     public function getType()
     {
         // Empty array, generic type
-        if (0 === sizeof($this->items)) {
+        if (0 === count($this->items)) {
             return new ListType(new GenericType(Meta::nextGenericVarName()));
         }
 

--- a/src/ast/expr/BlockExpr.php
+++ b/src/ast/expr/BlockExpr.php
@@ -39,7 +39,7 @@ class BlockExpr extends Expr
     {
         $source = '&{';
 
-        if (sizeof($this->body) > 0) {
+        if (count($this->body) > 0) {
             $source .= PHP_EOL;
             $parser->openScope();
             foreach ($this->body as $stmt) {

--- a/src/ast/expr/CallExpr.php
+++ b/src/ast/expr/CallExpr.php
@@ -66,8 +66,8 @@ class CallExpr extends Expr
         }
 
         // Check parameters length
-        $expected_arguments = sizeof($callee_type->parameters);
-        $received_arguments = sizeof($this->arguments);
+        $expected_arguments = count($callee_type->parameters);
+        $received_arguments = count($this->arguments);
 
         if ($received_arguments !== $expected_arguments) {
             throw new TypeError(Localization::message('TYP320',

--- a/src/ast/expr/LambdaExpr.php
+++ b/src/ast/expr/LambdaExpr.php
@@ -52,7 +52,7 @@ class LambdaExpr extends Expr
     {
         $source = '&';
 
-        switch (sizeof($this->parameters)) {
+        switch (count($this->parameters)) {
             case 0:
                 $source .= '[]';
                 break;

--- a/src/ast/expr/MapExpr.php
+++ b/src/ast/expr/MapExpr.php
@@ -46,7 +46,7 @@ class MapExpr extends Expr
         $keys = $this->keys;
         $values = $this->values;
 
-        if (sizeof($this->keys) > 0) {
+        if (count($this->keys) > 0) {
             $source .= ' ';
             // Iterate based on index
             $source .= implode(', ', array_map(function($index) use ($keys, $values, $parser) {
@@ -55,7 +55,7 @@ class MapExpr extends Expr
                 $subsource .= $values[$index]->format($parser);
 
                 return $subsource;
-            }, range(0, sizeof($keys) - 1)));
+            }, range(0, count($keys) - 1)));
             $source .= ' ';
         }
 
@@ -77,7 +77,7 @@ class MapExpr extends Expr
 
     public function getType()
     {
-        $size = sizeof($this->keys);
+        $size = count($this->keys);
 
         // Generic type when no initializer provided
         if (0 === $size) {

--- a/src/ast/expr/MatchExpr.php
+++ b/src/ast/expr/MatchExpr.php
@@ -52,7 +52,7 @@ class MatchExpr extends Expr
             return $subsource;
         }, $this->cases));
 
-        if (sizeof($this->cases) > 0 && null !== $this->else) {
+        if (count($this->cases) > 0 && null !== $this->else) {
             $source .= ',';
         }
 

--- a/src/ast/expr/ObjectExpr.php
+++ b/src/ast/expr/ObjectExpr.php
@@ -45,7 +45,7 @@ class ObjectExpr extends Expr
         $keys = $this->keys;
         $values = $this->values;
 
-        if (sizeof($this->keys) > 0) {
+        if (count($this->keys) > 0) {
             $source .= PHP_EOL;
 
             $parser->openScope();
@@ -59,7 +59,7 @@ class ObjectExpr extends Expr
                 $subsource .= $values[$index]->format($parser);
 
                 return $subsource;
-            }, range(0, sizeof($keys) - 1)));
+            }, range(0, count($keys) - 1)));
 
             $parser->closeScope();
 
@@ -77,7 +77,7 @@ class ObjectExpr extends Expr
         $defined = [];
         $operators = [];
         $index = 0;
-        while ($index < sizeof($this->keys)) {
+        while ($index < count($this->keys)) {
             $key = $this->keys[$index];
             $value = $this->values[$index];
             if (array_key_exists($key, $defined)) {
@@ -92,7 +92,7 @@ class ObjectExpr extends Expr
     public function getType()
     {
         $properties = [];
-        for ($i = 0, $size = sizeof($this->keys); $i < $size; $i++) {
+        for ($i = 0, $size = count($this->keys); $i < $size; $i++) {
             $properties[$this->keys[$i]] = $this->values[$i]->getType();
         }
 

--- a/src/ast/expr/WhereExpr.php
+++ b/src/ast/expr/WhereExpr.php
@@ -42,7 +42,7 @@ class WhereExpr extends Expr
     public function format(Parser $parser)
     {
         $first = true;
-        $size = sizeof($this->clauses);
+        $size = count($this->clauses);
         $processed = 0;
 
         $source = $this->expr->format($parser);

--- a/src/ast/stmt/FnStmt.php
+++ b/src/ast/stmt/FnStmt.php
@@ -119,7 +119,7 @@ class FnStmt extends Stmt
 
     private function injectParametersTypes($parameters_types)
     {
-        $size = sizeof($parameters_types);
+        $size = count($parameters_types);
         for ($i = 0; $i < $size; $i++) {
             $parameter = $this->signature->parameters[$i]->name;
             $type = $parameters_types[$i];

--- a/src/ast/types/FunctionType.php
+++ b/src/ast/types/FunctionType.php
@@ -60,8 +60,8 @@ class FunctionType extends TypeNode
         }
 
         // Functions with different number of arguments
-        $self_arity = sizeof($this->parameters);
-        $other_arity = sizeof($other->parameters);
+        $self_arity = count($this->parameters);
+        $other_arity = count($other->parameters);
         if ($self_arity !== $other_arity) {
             $message .= '     > ' . Localization::message('TYP360', [$self_arity, $other_arity]);
             throw new TypeError($message);

--- a/src/ast/types/ObjectType.php
+++ b/src/ast/types/ObjectType.php
@@ -58,7 +58,7 @@ class ObjectType extends TypeNode
 
         // Get all properties that are in this object but not in the other
         $different_properties = array_diff_key($this->properties, $other->properties);
-        if (sizeof($different_properties) > 0) {
+        if (count($different_properties) > 0) {
             // If there is something like %{a:1}, %{}, so, we are missing `a'
             return false;
         }

--- a/src/ast/types/TupleType.php
+++ b/src/ast/types/TupleType.php
@@ -33,7 +33,7 @@ class TupleType extends TypeNode
     public function __construct(...$types)
     {
         $this->types = $types;
-        $this->size = sizeof($types);
+        $this->size = count($types);
     }
 
     public function __toString()

--- a/src/cli/Component.php
+++ b/src/cli/Component.php
@@ -47,7 +47,7 @@ abstract class Component
             $result[] = $this->state[$prop];
         }
 
-        return 1 === sizeof($result)
+        return 1 === count($result)
             ? $result[0]
             : $result;
     }

--- a/src/cli/Repl.php
+++ b/src/cli/Repl.php
@@ -80,13 +80,13 @@ class Repl extends Component
 
     private function handleEnd()
     {
-        $this->setState(['column' => sizeof($this->state('line'))]);
+        $this->setState(['column' => count($this->state('line'))]);
     }
 
     private function handleDelete()
     {
         list ($line, $column) = $this->state('line', 'column');
-        if ($column === sizeof($line)) {
+        if ($column === count($line)) {
             return;
         }
 
@@ -103,7 +103,7 @@ class Repl extends Component
     private function handleRightArrow()
     {
         list ($line, $column) = $this->state('line', 'column');
-        $this->setState(['column' => min(sizeof($line), $column + 1)]);
+        $this->setState(['column' => min(count($line), $column + 1)]);
     }
 
     private function getBoundaries()
@@ -134,14 +134,14 @@ class Repl extends Component
             return $boundary[1] > $column;
         }));
 
-        $column = $next_boundary ? $next_boundary[1] : sizeof($line);
+        $column = $next_boundary ? $next_boundary[1] : count($line);
         $this->setState(['column' => $column]);
     }
 
     private function handleUpArrow()
     {
         list ($history, $index) = $this->state('history', 'history_index');
-        $line = @$history[sizeof($history) - ($index + 1)];
+        $line = @$history[count($history) - ($index + 1)];
         if (null !== $line) {
             $this->setState([
                 'line'          => str_split($line),
@@ -154,7 +154,7 @@ class Repl extends Component
     private function handleDownArrow()
     {
         list ($history, $index) = $this->state('history', 'history_index');
-        $line = @$history[sizeof($history) - ($index - 1)];
+        $line = @$history[count($history) - ($index - 1)];
         if (null !== $line) {
             $this->setState([
                 'line'          => str_split($line),
@@ -238,7 +238,7 @@ class Repl extends Component
     {
         $context = $this->state('scope')->child;
 
-        if (0 === sizeof($context->table)) {
+        if (0 === count($context->table)) {
             return;
         }
 

--- a/src/lexer/Tokenizer.php
+++ b/src/lexer/Tokenizer.php
@@ -127,7 +127,7 @@ class Tokenizer extends Lexer
 
             if ($found) {
                 $value = implode($buffer);
-                $this->column += sizeof($buffer);
+                $this->column += count($buffer);
                 return new Token($tag, $value);
             }
         }
@@ -159,7 +159,7 @@ class Tokenizer extends Lexer
         }
 
         $value = implode($buffer);
-        $this->column += sizeof($buffer);
+        $this->column += count($buffer);
         return new Token($tag, $value);
     }
 
@@ -184,7 +184,7 @@ class Tokenizer extends Lexer
         $string = implode($buffer);
 
         $word = $this->getWord($string);
-        $this->column += sizeof($buffer);
+        $this->column += count($buffer);
 
         if ($word !== null) {
             return $word;

--- a/src/parser/SyntaxError.php
+++ b/src/parser/SyntaxError.php
@@ -80,8 +80,8 @@ class SyntaxError extends Exception
         $out_buffer[] = $line_indicator;
         $out_buffer[] = BEGIN_GREEN . implode($correct_piece) . END_GREEN;
         $out_buffer[] = BEGIN_BG_RED . implode($error_piece) . END_BG_RED;
-        $out_buffer[] = PHP_EOL . str_repeat(' ', strlen($line_indicator) + sizeof($correct_piece));
-        $out_buffer[] = BEGIN_BOLD . str_repeat('^', sizeof($error_piece)) . END_BOLD;
+        $out_buffer[] = PHP_EOL . str_repeat(' ', strlen($line_indicator) + count($correct_piece));
+        $out_buffer[] = BEGIN_BOLD . str_repeat('^', count($error_piece)) . END_BOLD;
 
         return implode($out_buffer);
     }


### PR DESCRIPTION
Pretty self explanatory. Looks pretty simple. Tried to make sure I double checked all instances to make sure it wasn't just a flat out "find and replace" without reviewing.

'sizeof' deprecated? who knew. I've been using count() for quite a while though.

https://wiki.php.net/rfc/deprecations_php_7_2