### PR TITLE
Fix copyright headers

### DIFF
--- a/build.php
+++ b/build.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/node/quack.cc
+++ b/node/quack.cc
@@ -1,3 +1,23 @@
+/**
+ * Quack Compiler and toolkit
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
+ *
+ * This file is part of Quack.
+ *
+ * Quack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Quack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Quack.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include <node.h>
 #include <iostream>
 #include <fstream>

--- a/src/Main.php
+++ b/src/Main.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/Node.php
+++ b/src/ast/Node.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/AccessExpr.php
+++ b/src/ast/expr/AccessExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/ArrayExpr.php
+++ b/src/ast/expr/ArrayExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/AtomExpr.php
+++ b/src/ast/expr/AtomExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/BlockExpr.php
+++ b/src/ast/expr/BlockExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/BoolExpr.php
+++ b/src/ast/expr/BoolExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/CallExpr.php
+++ b/src/ast/expr/CallExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/Expr.php
+++ b/src/ast/expr/Expr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/LambdaExpr.php
+++ b/src/ast/expr/LambdaExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/MapExpr.php
+++ b/src/ast/expr/MapExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/MatchExpr.php
+++ b/src/ast/expr/MatchExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/NameExpr.php
+++ b/src/ast/expr/NameExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/NumberExpr.php
+++ b/src/ast/expr/NumberExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/ObjectExpr.php
+++ b/src/ast/expr/ObjectExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/OperatorExpr.php
+++ b/src/ast/expr/OperatorExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/PartialFuncExpr.php
+++ b/src/ast/expr/PartialFuncExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/PostfixExpr.php
+++ b/src/ast/expr/PostfixExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/PrefixExpr.php
+++ b/src/ast/expr/PrefixExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/RangeExpr.php
+++ b/src/ast/expr/RangeExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/RegexExpr.php
+++ b/src/ast/expr/RegexExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/StringExpr.php
+++ b/src/ast/expr/StringExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/TernaryExpr.php
+++ b/src/ast/expr/TernaryExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/TupleExpr.php
+++ b/src/ast/expr/TupleExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/expr/WhereExpr.php
+++ b/src/ast/expr/WhereExpr.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/stmt/BlockStmt.php
+++ b/src/ast/stmt/BlockStmt.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/stmt/BreakStmt.php
+++ b/src/ast/stmt/BreakStmt.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/stmt/ContinueStmt.php
+++ b/src/ast/stmt/ContinueStmt.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/stmt/ElifStmt.php
+++ b/src/ast/stmt/ElifStmt.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/stmt/ExprStmt.php
+++ b/src/ast/stmt/ExprStmt.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/stmt/FnSignatureStmt.php
+++ b/src/ast/stmt/FnSignatureStmt.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/stmt/FnStmt.php
+++ b/src/ast/stmt/FnStmt.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/stmt/ForeachStmt.php
+++ b/src/ast/stmt/ForeachStmt.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/stmt/IfStmt.php
+++ b/src/ast/stmt/IfStmt.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/stmt/LabelStmt.php
+++ b/src/ast/stmt/LabelStmt.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/stmt/LetStmt.php
+++ b/src/ast/stmt/LetStmt.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/stmt/ProgramStmt.php
+++ b/src/ast/stmt/ProgramStmt.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/stmt/ReturnStmt.php
+++ b/src/ast/stmt/ReturnStmt.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/stmt/Stmt.php
+++ b/src/ast/stmt/Stmt.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/stmt/TypeStmt.php
+++ b/src/ast/stmt/TypeStmt.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/stmt/WhileStmt.php
+++ b/src/ast/stmt/WhileStmt.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/types/AtomType.php
+++ b/src/ast/types/AtomType.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/types/FunctionType.php
+++ b/src/ast/types/FunctionType.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/types/GenericType.php
+++ b/src/ast/types/GenericType.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/types/ListType.php
+++ b/src/ast/types/ListType.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/types/LiteralType.php
+++ b/src/ast/types/LiteralType.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/types/MapType.php
+++ b/src/ast/types/MapType.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/types/NameType.php
+++ b/src/ast/types/NameType.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/types/ObjectType.php
+++ b/src/ast/types/ObjectType.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/types/OperatorType.php
+++ b/src/ast/types/OperatorType.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/types/TupleType.php
+++ b/src/ast/types/TupleType.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/ast/types/TypeNode.php
+++ b/src/ast/types/TypeNode.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/cli/Component.php
+++ b/src/cli/Component.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/cli/Console.php
+++ b/src/cli/Console.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/cli/Croak.php
+++ b/src/cli/Croak.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/cli/Repl.php
+++ b/src/cli/Repl.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/intl/Localization.php
+++ b/src/intl/Localization.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/lexer/Lexer.php
+++ b/src/lexer/Lexer.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/lexer/SymbolDecypher.php
+++ b/src/lexer/SymbolDecypher.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/lexer/Tag.php
+++ b/src/lexer/Tag.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/lexer/Token.php
+++ b/src/lexer/Token.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/lexer/Tokenizer.php
+++ b/src/lexer/Tokenizer.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/lexer/Word.php
+++ b/src/lexer/Word.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/InfixParselet.php
+++ b/src/parselets/InfixParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/Parselet.php
+++ b/src/parselets/Parselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/PrefixParselet.php
+++ b/src/parselets/PrefixParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/expr/AccessParselet.php
+++ b/src/parselets/expr/AccessParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/expr/ArrayParselet.php
+++ b/src/parselets/expr/ArrayParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/expr/BinaryOperatorParselet.php
+++ b/src/parselets/expr/BinaryOperatorParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/expr/BlockParselet.php
+++ b/src/parselets/expr/BlockParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/expr/CallParselet.php
+++ b/src/parselets/expr/CallParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/expr/GroupParselet.php
+++ b/src/parselets/expr/GroupParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/expr/LambdaParselet.php
+++ b/src/parselets/expr/LambdaParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/expr/LiteralParselet.php
+++ b/src/parselets/expr/LiteralParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/expr/MapParselet.php
+++ b/src/parselets/expr/MapParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/expr/MatchParselet.php
+++ b/src/parselets/expr/MatchParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/expr/MemberAccessParselet.php
+++ b/src/parselets/expr/MemberAccessParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/expr/NameParselet.php
+++ b/src/parselets/expr/NameParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/expr/ObjectParselet.php
+++ b/src/parselets/expr/ObjectParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/expr/PartialFuncParselet.php
+++ b/src/parselets/expr/PartialFuncParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/expr/PostfixOperatorParselet.php
+++ b/src/parselets/expr/PostfixOperatorParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/expr/PrefixOperatorParselet.php
+++ b/src/parselets/expr/PrefixOperatorParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/expr/RangeParselet.php
+++ b/src/parselets/expr/RangeParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/expr/TernaryParselet.php
+++ b/src/parselets/expr/TernaryParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/expr/TupleParselet.php
+++ b/src/parselets/expr/TupleParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/expr/WhereParselet.php
+++ b/src/parselets/expr/WhereParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/types/AtomTypeParselet.php
+++ b/src/parselets/types/AtomTypeParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/types/BinaryOperatorTypeParselet.php
+++ b/src/parselets/types/BinaryOperatorTypeParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/types/FunctionTypeParselet.php
+++ b/src/parselets/types/FunctionTypeParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/types/GroupTypeParselet.php
+++ b/src/parselets/types/GroupTypeParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/types/ListTypeParselet.php
+++ b/src/parselets/types/ListTypeParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/types/LiteralTypeParselet.php
+++ b/src/parselets/types/LiteralTypeParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/types/MapTypeParselet.php
+++ b/src/parselets/types/MapTypeParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/types/NameTypeParselet.php
+++ b/src/parselets/types/NameTypeParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/types/ObjectTypeParselet.php
+++ b/src/parselets/types/ObjectTypeParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parselets/types/TupleTypeParselet.php
+++ b/src/parselets/types/TupleTypeParselet.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parser/Attachable.php
+++ b/src/parser/Attachable.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parser/DeclParser.php
+++ b/src/parser/DeclParser.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parser/EOFError.php
+++ b/src/parser/EOFError.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parser/ExprParser.php
+++ b/src/parser/ExprParser.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parser/NameParser.php
+++ b/src/parser/NameParser.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parser/Parser.php
+++ b/src/parser/Parser.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parser/Precedence.php
+++ b/src/parser/Precedence.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parser/StmtParser.php
+++ b/src/parser/StmtParser.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parser/SyntaxError.php
+++ b/src/parser/SyntaxError.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parser/TokenReader.php
+++ b/src/parser/TokenReader.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/parser/TypeParser.php
+++ b/src/parser/TypeParser.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/scope/Kind.php
+++ b/src/scope/Kind.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/scope/Meta.php
+++ b/src/scope/Meta.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/scope/Scope.php
+++ b/src/scope/Scope.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/scope/ScopeError.php
+++ b/src/scope/ScopeError.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/toolkit/QuackToolkit.php
+++ b/src/toolkit/QuackToolkit.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/types/NativeQuackType.php
+++ b/src/types/NativeQuackType.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *

--- a/src/types/TypeError.php
+++ b/src/types/TypeError.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Quack Compiler and toolkit
- * Copyright (C) 2016 Marcelo Camargo <marcelocamargo@linuxmail.org> and
- * CONTRIBUTORS.
+ * Copyright (C) 2015-2017 Quack and CONTRIBUTORS
  *
  * This file is part of Quack.
  *


### PR DESCRIPTION
Replaces the old notation of copyright by a new one including every
:duck: of the project.

Signed-off-by: Rafael Campos Nunes <rafaelnunes@engineer.com>